### PR TITLE
Component markup

### DIFF
--- a/fractal.config.js
+++ b/fractal.config.js
@@ -20,7 +20,7 @@ fractal.set('project.title', pkg.project.title)
 fractal.set('project.package', pkg)
 
 const nunjucks = require('@frctl/nunjucks')({
-  paths: ['src/templates'],
+  paths: ['src/components'],
   filters: {
     iconify (content) {
       if (content && content.icon) {

--- a/src/components/button/button.html
+++ b/src/components/button/button.html
@@ -1,4 +1,4 @@
-{% macro button(properties) %}
+{% macro button(label, prefix, suffix, class) %}
   {% include "./button/markup.html" %}
 {% endmacro %}
 
@@ -30,9 +30,8 @@
               <td class="pl-2 py-1 {{ content.cell.class }} {{ orient.cell.class }} {{ state.cell.class }}">
                 {% set label = context.text | default(text) %}
                 {% set modifiers = [class, orient.class, state.class] | join(' ') %}
-                {% set properties = {label: label, prefix: prefix, suffix: content.suffix, modifiers: modifiers} %}
                 
-                {{ button(properties) }}
+                {{ button(label, content.prefix, content.suffix, modifiers) }}
               </td>
             {% endfor %}
           </tr>

--- a/src/components/button/button.html
+++ b/src/components/button/button.html
@@ -1,13 +1,5 @@
-{% macro button(label, prefix, suffix, class) %}
-  <button class="{{ class }}">
-    {% if prefix.icon %}
-      <sfgov-icon symbol="{{ prefix.icon }}" class="mr-1"></sfgov-icon>
-    {% endif %}
-    <span>{{ label }}</span>
-    {% if suffix.icon %}
-      <sfgov-icon symbol="{{ suffix.icon }}" class="ml-1"></sfgov-icon>
-    {% endif %}
-  </button>
+{% macro button(properties) %}
+  {% include "./button/markup.html" %}
 {% endmacro %}
 
 <div class="p-4 h-screen {{ wrapper.class }}">
@@ -38,7 +30,9 @@
               <td class="pl-2 py-1 {{ content.cell.class }} {{ orient.cell.class }} {{ state.cell.class }}">
                 {% set label = context.text | default(text) %}
                 {% set modifiers = [class, orient.class, state.class] | join(' ') %}
-                {{ button(label, content.prefix, content.suffix, modifiers) }}
+                {% set properties = {label: label, prefix: prefix, suffix: content.suffix, modifiers: modifiers} %}
+                
+                {{ button(properties) }}
               </td>
             {% endfor %}
           </tr>

--- a/src/components/button/button.html
+++ b/src/components/button/button.html
@@ -30,7 +30,6 @@
               <td class="pl-2 py-1 {{ content.cell.class }} {{ orient.cell.class }} {{ state.cell.class }}">
                 {% set label = context.text | default(text) %}
                 {% set modifiers = [class, orient.class, state.class] | join(' ') %}
-                
                 {{ button(label, content.prefix, content.suffix, modifiers) }}
               </td>
             {% endfor %}

--- a/src/components/button/markup.html
+++ b/src/components/button/markup.html
@@ -1,0 +1,9 @@
+<button class="{{ properties.modifiers }}">
+  {% if properties.prefix.icon %}
+    <sfgov-icon symbol="{{ properties.prefix.icon }}" class="mr-1"></sfgov-icon>
+  {% endif %}
+  <span>{{ properties.label }}</span>
+  {% if properties.suffix.icon %}
+    <sfgov-icon symbol="{{ properties.suffix.icon }}" class="ml-1"></sfgov-icon>
+  {% endif %}
+</button>

--- a/src/components/button/markup.html
+++ b/src/components/button/markup.html
@@ -1,9 +1,9 @@
-<button class="{{ properties.modifiers }}">
-  {% if properties.prefix.icon %}
-    <sfgov-icon symbol="{{ properties.prefix.icon }}" class="mr-1"></sfgov-icon>
+<button class="{{ class }}">
+  {% if prefix.icon %}
+    <sfgov-icon symbol="{{ prefix.icon }}" class="mr-1"></sfgov-icon>
   {% endif %}
-  <span>{{ properties.label }}</span>
-  {% if properties.suffix.icon %}
-    <sfgov-icon symbol="{{ properties.suffix.icon }}" class="ml-1"></sfgov-icon>
+  <span>{{ label }}</span>
+  {% if suffix.icon %}
+    <sfgov-icon symbol="{{ suffix.icon }}" class="ml-1"></sfgov-icon>
   {% endif %}
 </button>


### PR DESCRIPTION
* updates the nunjucks path
* separates button markup into its own file and include in button macro

@shawnbot the purpose of this was to have a single button markup file that we could use for import into other templates on the sf.gov drupal theme side.

i haven't figured out how to get just the markup to show up in the fractal static site, though, so it can be a standalone reference for expected markup for the button component.

tried to add in another panel in the mandlebrot theme, but think it requires customizing the theme itself to pick up a tab like "markup"