### PR TITLE
Fix release branch for primer/publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,6 @@ jobs:
       - run: npm run build-docs
 
       - uses: primer/publish@v2.0.0
-        with:
-          default-branch: main
         env:
           GITHUB_TOKEN: ${{ github.token }}
           NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -13,6 +13,9 @@
     "src",
     "tailwind.config.js"
   ],
+  "@primer/publish": {
+    "releaseBranch": "main"
+  },
   "scripts": {
     "build": "run-s build-css build-js build-docs",
     "build-docs": "fractal build",


### PR DESCRIPTION
If we merge this to main it _should_ publish v0.0.2 to npm. 🤞 