### PR TITLE
Switch back to primer/publish v3.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,10 @@ jobs:
       - run: npm run build-js
       - run: npm run build-docs
 
-      - uses: primer/publish@v2.0.0
+      - uses: primer/publish@v3.0.0
+        with:
+          npm_args: --unsafe-perm --allow-same-version
+          release_branch: main
         env:
           GITHUB_TOKEN: ${{ github.token }}
           NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -13,9 +13,6 @@
     "src",
     "tailwind.config.js"
   ],
-  "@primer/publish": {
-    "releaseBranch": "main"
-  },
   "scripts": {
     "build": "run-s build-css build-js build-docs",
     "build-docs": "fractal build",


### PR DESCRIPTION
Well, I tried to fix publishing from the `main` branch in #11, but [it didn't work](https://github.com/SFDigitalServices/design-system/runs/2256983966#step:11:70). I'm going back to [primer/publish v3.0.0](https://github.com/primer/publish/releases/tag/v3.0.0) and using the `default_branch` workflow input. Let's merge this, and if it doesn't work I'll just publish it manually.