### PR TITLE
Button fixes

### DIFF
--- a/src/components/button/button.html
+++ b/src/components/button/button.html
@@ -11,6 +11,21 @@
 {% endmacro %}
 
 <div class="p-4 h-screen {{ wrapper.class }}">
+  <div class="mb-2">
+    <h2>Links</h2>
+    <a href="javascript:void(0)" class="{{ class }}">This is a link</a>
+    <br>
+    <a href="javascript:void(0)" class="{{ class }} btn-block">This is a block link</a>
+  </div>
+
+  <div class="mb-2">
+    <h2>Buttons</h2>
+    <button class="{{ class }}">This is a button</button>
+    <br>
+    <button class="{{ class }} btn-block">This is a block button</button>
+  </div>
+
+  <h2>States</h2>
   <table>
     <thead>
       <tr>

--- a/src/css/base.css
+++ b/src/css/base.css
@@ -4,6 +4,7 @@
   * {
     @apply font-rubik;
     @apply text-body;
+    box-sizing: border-box;
   }
 
   @layer base {

--- a/src/css/components/button.css
+++ b/src/css/components/button.css
@@ -8,6 +8,7 @@
     @apply px-2 py-1;
     @apply bg-blue-bright;
     @apply text-white;
+    @apply no-underline;
     @apply border-0 border-solid border-current;
     @apply text-center justify-center items-center;
     @apply whitespace-nowrap;

--- a/src/css/components/button.css
+++ b/src/css/components/button.css
@@ -15,6 +15,9 @@
 
     @apply hocus:bg-blue-dark;
 
+    /* FIXME: this should be applied by base */
+    box-sizing: border-box;
+
     &.hover,
     &.focus {
       @apply bg-blue-dark;

--- a/src/css/components/button.css
+++ b/src/css/components/button.css
@@ -1,6 +1,6 @@
 @layer components {
   .btn {
-    @apply flex;
+    @apply inline-flex;
     @apply appearance-none;
     @apply cursor-pointer;
     @apply font-semibold;
@@ -45,11 +45,7 @@
     }
   }
 
-  .btn-inline {
-    @apply inline-flex;
-  }
-
   .btn-block {
-    @apply w-full;
+    @apply flex w-full;
   }
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -45,6 +45,7 @@ module.exports = {
     'margin',
     'textAlign',
     'textColor',
+    'textDecoration',
     'verticalAlign',
     'whitespace',
     'width'
@@ -81,6 +82,7 @@ module.exports = {
     stroke: [],
     strokeWidth: [],
     textColor: ['focus', 'hover', 'hocus'],
+    textDecoration: ['focus', 'hover', 'hocus'],
     userSelect: [],
     verticalAlign: ['responsive'],
     width: ['responsive']


### PR DESCRIPTION
This PR fixes some issues with my first pass on button styles:

1. `.btn` now gets `display: inline-flex` instead of `display: flex`. This allows them to "shrink-wrap" to their contents' width. Adding `.btn-block` makes it `display: flex` and full-width.
2. Buttons now get `text-decoration: none` via the `no-underline` Tailwind utility.
3. Buttons _and_ the `*` selector (defined in our base styles) now both get `box-sizing: border-box` so that padding works correctly.

The [button component template](https://design-system-git-button-fixes-sfds.vercel.app/components/detail/button--default.html) also now renders both inline and block variations of both a link (`<a>`) and a `<button>` element with the `btn` class so that we can spot-check them. The rendering is not great, so let's fix that before merging:

![image](https://user-images.githubusercontent.com/113896/113948856-b6b99f80-97c2-11eb-9816-6ed77d22e329.png)

@aekong You can test this by installing `sfgov-design-system@0.0.0-12f9409`. If this works for you, let's start a release branch for it and merge to that.