### PR TITLE
Add Link button variant + CSS

### DIFF
--- a/src/components/button/button.config.yml
+++ b/src/components/button/button.config.yml
@@ -45,3 +45,8 @@ variants:
       class: btn btn-inverse
       wrapper:
         class: bg-yellow-3
+
+  - name: link
+    label: Link
+    context:
+      class: btn btn-link

--- a/src/css/components/button.css
+++ b/src/css/components/button.css
@@ -46,6 +46,17 @@
     }
   }
 
+  .btn-link {
+    @apply border-0 hocus:border-0;
+    @apply bg-none text-blue-bright;
+    @apply hover:bg-none hover:text-blue-dark;
+
+    &.hover,
+    &.focus {
+      @apply bg-none text-blue-dark;
+    }
+  }
+
   .btn-block {
     @apply flex w-full;
   }

--- a/src/tokens/colors.js
+++ b/src/tokens/colors.js
@@ -1,4 +1,5 @@
 module.exports = {
+  none: 'transparent',
   white: '#FFF',
   black: '#212123',
   blue: {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -70,6 +70,7 @@ module.exports = {
     appearance: [],
     backgroundColor: ['focus', 'hover', 'hocus'],
     borderColor: ['focus', 'hover', 'hocus'],
+    borderWidth: ['hocus'],
     cursor: [],
     display: ['responsive'],
     fill: [],


### PR DESCRIPTION
This PR adds a new "Link" variant to our button component, styled with the `btn-link` class:

```html
<button class="btn btn-link">Do something!</button>
```

[:eyes: Preview](https://sfgov-design-system-pr-33.herokuapp.com/components/detail/button--link.html)

Really the `.btn-link` CSS just "undoes" most of the border + color styles that `.btn` adds. This might seem silly, but I think that it's good to have consistency in how you add `btn` class variants so that it's obvious how to change an instance of one variant into another: i.e. by changing `btn btn-secondary` to `btn btn-link`, rather than `btn btn-secondary` to `btn-link` (or vice-versa: `btn-link` to `btn btn-secondary`).

It would be good to have support for this in [the Buttons Figma doc](https://www.figma.com/file/mHhKyF2UhNOecuRZj266R8/_2021-Buttons?node-id=0%3A1) before merging.