### PR TITLE
Add "auto" to theme.width

### DIFF
--- a/src/theme.js
+++ b/src/theme.js
@@ -27,6 +27,7 @@ module.exports = {
     ...theme('width')
   }),
   width: {
+    auto: 'auto',
     '1/2': '50%',
     '2/2': '100%',
     '1/3': '33.3333333%',


### PR DESCRIPTION
This adds an `auto` entry to our theme's `width` config, giving us responsive utilities to set `width: auto !important`. This is needed for FM-11 to center the Browse button and make it full width by default (left), then "shrink" it to auto width (and `display: inline-flex`) on larger viewports (right):

Small | Large
:--- | :---
![image](https://user-images.githubusercontent.com/113896/127225220-880d7a99-9b97-420c-8060-511711e56847.png) | ![image](https://user-images.githubusercontent.com/113896/127225064-77a3ff6e-7a4a-4aaf-a237-85e7f7ed95f1.png)

In this case, I'm thinking the markup should look like:

```html
<div class="align-center">
  <span class="mx-8">Drop files to attach, or</span>
  <button class="
    btn btn-block mt-8
    lg:inline-flex lg:w-auto lg:mt-0
  ">Browse</button>
</div>
```

Another solution would be to give `btn-block` and other modifiers [responsive variants](https://tailwindcss.com/docs/functions-and-directives#variants) (e.g. `btn-block lg:btn-inline`), but that opens a whole other can of worms that I'd rather not deal with yet.