### PR TITLE
Add preactjs/compressed-size-action reports to PRs

### DIFF
--- a/.github/workflows/reports.yml
+++ b/.github/workflows/reports.yml
@@ -1,0 +1,12 @@
+name: Reports
+on: [pull_request]
+
+jobs:
+  reports:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: preactjs/compressed-size-action@v2
+        with:
+          repo-token: ${{ github.token }}
+          pattern: 'dist/**/*.{css,js}'


### PR DESCRIPTION
[This action](https://github.com/preactjs/compressed-size-action#readme) comments on pull requests with  changes in size to any of the built files. We use it on [formio-sfds](/sfdigitalservices/formio-sfds) and it works great. I'm a bit scared to see what it says about our 2.0.0 CSS bundle size 😬 