### PR TITLE
refactor typography tokens to be mobile first

### DIFF
--- a/docs/foundations/typography.md
+++ b/docs/foundations/typography.md
@@ -54,28 +54,28 @@ with color banner) or display [large](#large-title) (pages with no color
 banner) to style the one-time page title (`<h1>`).
 
 #### X-large title
-> <div class="title-xl">{{ specimens.default }}</div>
+> <div class="title-xl-desktop">{{ specimens.default }}</div>
 
 #### Large title
-> <div class="title-lg">{{ specimens.default }}</div>
+> <div class="title-lg-desktop">{{ specimens.default }}</div>
 
 #### Medium title
-> <div class="title-md">{{ specimens.default }}</div>
+> <div class="title-md-desktop">{{ specimens.default }}</div>
 
 #### Small title
-> <div class="title-sm">{{ specimens.default }}</div>
+> <div class="title-sm-desktop">{{ specimens.default }}</div>
 
 #### X-small title
-> <div class="title-xs">{{ specimens.default }}</div>
+> <div class="title-xs-desktop">{{ specimens.default }}</div>
 
 #### X-small title link
-> <div class="title-xs"><a href="#">{{ specimens.default }}</a></div>
+> <div class="title-xs-desktop"><a href="#">{{ specimens.default }}</a></div>
 
 #### Display large
-> <div class="display-lg">{{ specimens.default }}</div>
+> <div class="display-lg-desktop">{{ specimens.default }}</div>
 
 #### Display small
-> <div class="display-sm">{{ specimens.default }}</div>
+> <div class="display-sm-desktop">{{ specimens.default }}</div>
 
 ### Additional text styles
 
@@ -84,7 +84,7 @@ Use to draw attention to blocks of text, such as the page introduction
 paragraph. This style is slightly larger in size and line height compared to
 the regular body text style.
 
-> <div class="big-desc">{{ specimens.default }}</div>
+> <div class="big-desc-desktop">{{ specimens.default }}</div>
 
 #### Body
 Use for paragraph and list text. This style can be used in regular, bold and

--- a/src/css/docs.css
+++ b/src/css/docs.css
@@ -36,6 +36,63 @@
   }
 }
 
+/* Below is for hard-coding mobile/desktop examples */
+.display-lg-mobile {
+  @apply text-display-lg font-light;
+}
+
+.display-lg-desktop {
+  @apply text-display-lg-desktop font-light;
+}
+
+.display-sm-mobile {
+  @apply text-display-sm font-light;
+}
+
+.display-sm-desktop {
+  @apply text-display-sm-desktop font-light;
+}
+
+.title-xl-mobile {
+  @apply text-title-xl font-medium;
+}
+
+.title-xl-desktop {
+  @apply text-title-xl-desktop font-medium;
+}
+
+.title-lg-mobile {
+  @apply text-title-lg font-medium;
+}
+
+.title-lg-desktop {
+  @apply text-title-lg-desktop font-medium;
+}
+
+.title-md-mobile {
+  @apply text-title-md font-medium;
+}
+
+.title-md-desktop {
+  @apply text-title-md-desktop font-medium;
+}
+
+.title-sm-desktop {
+  @apply text-title-sm-desktop font-medium;
+}
+
+.title-xs-desktop {
+  @apply text-title-xs-desktop font-medium;
+}
+
+.big-desc-mobile {
+  @apply text-big-desc font-regular;
+}
+
+.big-desc-desktop {
+  @apply text-big-desc-desktop font-regular;
+}
+
 /**
  * The following are "scopes" defined by highlight.js:
  * <https://highlightjs.readthedocs.io/en/latest/css-classes-reference.html>

--- a/src/css/typography.css
+++ b/src/css/typography.css
@@ -28,39 +28,27 @@
   }
 
   .display-lg {
-    font-size: 44px;
-    line-height: 48px;
-    @apply font-light tracking-n1;
+    @apply text-display-lg font-light;
   }
 
   .display-sm {
-    font-size: 36px;
-    line-height: 40px;
-    @apply font-light tracking-n1;
+    @apply text-display-sm font-light;
   }
 
   .title-xl {
-    font-size: 32px;
-    line-height: 36px;
-    @apply font-medium tracking-n1;
+    @apply text-title-xl font-medium;
   }
 
   .title-lg {
-    font-size: 28px;
-    line-height: 32px;
-    @apply font-medium tracking-n1;
+    @apply text-title-lg font-medium;
   }
 
   .title-md {
-    font-size: 24px;
-    line-height: 28px;
-    @apply font-medium;
+    @apply text-title-md font-medium;
   }
 
   .big-desc {
-    font-size: 20px;
-    line-height: 28px;
-    @apply font-regular;
+    @apply text-big-desc font-regular;
   }
 
   .small {
@@ -73,51 +61,35 @@
 
   @screen lg {
     .display-lg {
-      font-size: 72px;
-      line-height: 76px;
-      @apply font-light tracking-n2;
+      @apply text-display-lg-desktop font-light;
     }
 
     .display-sm {
-      font-size: 48px;
-      line-height: 52px;
-      @apply font-light tracking-n1;
+      @apply text-display-sm-desktop font-light;
     }
 
     .title-xl {
-      font-size: 60px;
-      line-height: 64px;
-      @apply tracking-n1;
+      @apply text-title-xl-desktop;
     }
 
     .title-lg {
-      font-size: 44px;
-      line-height: 52px;
-      @apply tracking-n1;
+      @apply text-title-lg-desktop;
     }
 
     .title-md {
-      font-size: 32px;
-      line-height: 36px;
-      @apply font-medium;
+      @apply text-title-md-desktop font-medium;
     }
 
     .title-sm {
-      font-size: 24px;
-      line-height: 28px;
-      @apply font-medium;
+      @apply text-title-sm-desktop font-medium;
     }
 
     .title-xs {
-      font-size: 20px;
-      line-height: 24px;
-      @apply font-medium;
+      @apply text-title-xs-desktop font-medium;
     }
 
     .big-desc {
-      font-size: 24px;
-      line-height: 32px;
-      @apply font-regular;
+      @apply text-big-desc-desktop font-regular;
     }
   }
 }

--- a/src/tokens/typography.js
+++ b/src/tokens/typography.js
@@ -12,13 +12,46 @@ const fontWeight = {
 module.exports = {
   fontFamily,
   fontSize: {
+    'display-lg': ['44px', {
+      letterSpacing: '-1px',
+      lineHeight: '48px'
+    }],
+    'display-sm': ['36px', {
+      letterSpacing: '-1px',
+      lineHeight: '40px'
+    }],
+    'title-xl': ['32px', {
+      letterSpacing: '-1px',
+      lineHeight: '36px'
+    }],
+    'title-lg': ['28px', {
+      letterSpacing: '-1px',
+      lineHeight: '32px'
+    }],
+    'title-md': ['24px', '28px'],
+    'big-desc': ['20px', '28px'],
+    'display-lg-desktop': ['72px', {
+      letterSpacing: '-2px',
+      lineHeight: '76px'
+    }],
+    'display-sm-desktop': ['48px', {
+      letterSpacing: '-1px',
+      lineHeight: '52px'
+    }],
+    'title-xl-desktop': ['60px', {
+      letterSpacing: '-1px',
+      lineHeight: '64px'
+    }],
+    'title-lg-desktop': ['44px', {
+      letterSpacing: '-1px',
+      lineHeight: '52px'
+    }],
+    'title-md-desktop': ['32px', '36px'],
+    'title-sm-desktop': ['24px', '28px'],
+    'title-xs-desktop': ['20px', '24px'],
+    'big-desc-desktop': ['24px', '32px'],
     body: ['16px', '24px'],
     small: ['14px', '18px']
   },
-  fontWeight,
-  letterSpacing: {
-    0: '0',
-    n1: '-1px',
-    n2: '-2px'
-  }
+  fontWeight
 }


### PR DESCRIPTION
I ended up leaving the `letterSpacing` values untouched, just to avoid bulking up the `typography.js` file, and since we only ever use two values: `-1px` and `-2px`. If folks think it'd make the tokens self-document better, I'm happy to make the declarations for each token more explicit.

Also, as another alternative, it looks like there's a shorthand for hitting all three text attributes (`fontSize`, `lineHeight`, `letterSpacing`) by doing e.g.:
```
fontSize: {
    'display-lg': ['44px', {
        letterSpacing: '-1px',
        lineHeight: '48px'
    }]
}
```