### PR TITLE
add last child variant to margin utilities

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -94,7 +94,7 @@ module.exports = {
     overflow: [],
     padding: ['responsive'],
     position: ['responsive'],
-    margin: ['responsive'],
+    margin: ['responsive', 'last'],
     maxWidth: ['responsive'],
     space: ['responsive'],
     stroke: [],


### PR DESCRIPTION
This pr adds the `last-child` tailwind variant to the `margin` utilities.

Use case: components generated in a loop need to have the margin stripped off the last item.

For example given an array of `items`,  apply a right margin to all except the last item:
```
  <div class="flex flex-row">
    {% for item in items %}
        <a href="some-url" class="mr-20 last:mr-0">
          <div>some content</div>
        </a>
    {% endfor %}
  </div>
```

In progress use case here: https://pr-1118-sfgov.pantheonsite.io/departments/office-city-administrator/office-civic-engagement-and-immigrant-affairs (cards above the "In this page" navigation)

The update requested in this pr adds a decent amount of kB to the dist, but in the case of sf.gov, the variant classes that aren't found to be in use in the markup are purged during build (thanks to @shawnbot!).  However, since we're attempting to make this design system available for use for other digital services/depts that _may not_ have PurgeCSS as part of the build process, this requested change may not be worth it.  But I'll leave that to the reviewers to decide.  Just thought I'd shoot my shot 😅 