### PR TITLE
Add group-hover variant

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -85,12 +85,12 @@ module.exports = {
     accessibility: ['responsive', 'focus', 'hocus'],
     appearance: [],
     // TODO [^3]: nix 'focus' + 'hover'
-    backgroundColor: ['focus', 'hover', 'hocus', 'group-hocus', 'details'],
+    backgroundColor: ['focus', 'hover', 'hocus', 'group-hocus', 'group-hover', 'details'],
     // TODO [^3]: nix 'focus' + 'hover'
-    borderColor: ['focus', 'hover', 'hocus', 'group-hocus', 'details'],
+    borderColor: ['focus', 'hover', 'hocus', 'group-hocus', 'group-hover', 'details'],
     borderWidth: ['hocus'],
     cursor: [],
-    display: ['responsive', 'group-hocus', 'details'],
+    display: ['responsive', 'group-hocus', 'group-hover', 'details'],
     fill: [],
     fontWeight: ['responsive'],
     fontSize: ['responsive'],
@@ -119,12 +119,12 @@ module.exports = {
     stroke: [],
     strokeWidth: [],
     // TODO [^3]: nix 'focus' + 'hover'
-    textColor: ['focus', 'hover', 'hocus', 'group-hocus', 'details'],
+    textColor: ['focus', 'hover', 'hocus', 'group-hocus', 'group-hover', 'details'],
     // TODO [^3]: nix 'focus' + 'hover'
     textDecoration: ['focus', 'hover', 'hocus'],
     userSelect: [],
     verticalAlign: ['responsive'],
-    visibility: ['responsive', 'group-hocus'],
+    visibility: ['responsive', 'group-hocus', 'group-hover'],
     width: ['responsive'],
     zIndex: ['responsive']
   },


### PR DESCRIPTION
Adding `group-hover` variant to facilitate [styling based on parent state](https://tailwindcss.com/docs/hover-focus-and-other-states#styling-based-on-parent-state).

For something like this:

|default|hover (white border)|
|---|---|
|<img width="305" alt="Screen Shot 2021-12-21 at 12 37 46 AM" src="https://user-images.githubusercontent.com/19291154/146899269-52142e2e-77c5-41c6-bbc0-a783da904aed.png">|<img width="307" alt="Screen Shot 2021-12-21 at 12 37 54 AM" src="https://user-images.githubusercontent.com/19291154/146899375-43cea3c3-8ba8-4ddc-be47-0e41aca4c5ba.png">|


