### PR TITLE
docs: fix package version on main branch

### DIFF
--- a/docs/_data/package.js
+++ b/docs/_data/package.js
@@ -1,9 +1,12 @@
 const pkg = require('../../package.json')
-const { github, context, sha } = require('../../lib/git')
+const { github, context, branch, defaultBranch, sha } = require('../../lib/git')
 
-let version
+// if we're on the main branch, just use the version in package.json
+let version = (branch === defaultBranch) ? pkg.version : undefined
 
 module.exports = async function getPackageWithVersion () {
+  // if no version was set yet, try to figure out the version published by
+  // GitHub Actions
   if (!version) {
     version = await getPublishedStatusVersion() || pkg.version
   }


### PR DESCRIPTION
I think I figured out the bug with the package version, but I want to test this out by merging to main just to be sure. This doesn't touch our published code, so I don't think we need a release for it.

When I was adding the package heading to the docs site, I wanted it to work with prerelease and canary versions, which aren't committed to git. Heroku and GitHub Actions run in parallel, and but more often than not (citation needed!) the publish action finishes first, the docs build on Heroku finds the commit status for the head SHA, and uses that as the version in the header. However, if Heroku builds first, the GitHub API query we're using might also be finding the commit status for previous release version and defaulting to that.

There are a couple of different ways that we could go about this:

0. [This PR] Skip the published version check when we're on the `main` branch.

1. Only use the published version if [`semver.gt(published, pkg.version)`](https://www.npmjs.com/package/semver#comparison). This would mean that if Heroku builds first it will _not_ get the right package version, so the links to published files will be incorrect.

2. Block Heroku from building until we find the correct published version. This could be tricky, because currently the publish action we're using fails on force-pushes to a previously pushed SHA, which would make the Heroku build out-of-date.

3. Pre-calculate the correct (prerelease or canary) version the same way that the publish action does. The "algorithm" is simple, so pre-calculating is easy:

    ```js
    function getPublishedStatusVersion () {
      const match = branch.match(/^release-(.+)$/)
      if (match) {
        return `${match[1]}-rc.${sha}`
      } else if (branch === defaultBranch) {
        return pkg.version
      }
      return `0.0.0-${sha}`
    }
    ```

4. Defer the resolution of the version promise until a publish commit status is available. Something like:

    ```js
    return retry(getPublishedStatusVersion, {
      // retry until this function returns true with the resolved value
      until: published => published.startsWith('0.0.0') || published.startsWith(pkg.version),
      // give up after 30 seconds
      timeout: 30
    })
    ```