### PR TITLE
Release 2.2.2

### DIFF
--- a/docs/_includes/head.njk
+++ b/docs/_includes/head.njk
@@ -7,6 +7,9 @@
 <meta charset="utf-8">
 <meta name="viewport" content="{{ meta.viewport | default('width=device-width,initial-scale=1') }}">
 <link rel="shortcut icon" href="https://sf.gov/themes/custom/sfgovpl/favicon.ico" type="image/vnd.microsoft.icon">
+{# these speed up Google Fonts requests considerably #}
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 {% for style in assets.styles %}
   {% if style.href %}
     <link href="{{ style.href }}"

--- a/docs/foundations/typography.md
+++ b/docs/foundations/typography.md
@@ -5,12 +5,13 @@ specimens:
 ---
 
 ## Introduction
-Our typeface is Rubik, which was designed by Hubert and Fischer in 2015 for
-Google Fonts. It is an open-source typeface that comes in 5 weights with
-Roman and Italic styles, and can be accessed for free through [Google
-Fonts][rubik].
+Our typeface is [Rubik], which was designed by Hubert and Fischer in 2015 for
+Google. It is an open-source typeface that comes in 5 weights with Roman and
+Italic styles, and is available for free from [Google Fonts].
 
-We are primarily using only 3 of Rubik’s weights: Light, Regular, and Semibold.
+We are primarily using only 3 of Rubik’s weights: Light
+({{ theme.fontWeight.light }}), Regular ({{ theme.fontWeight.regular }}), and
+Semibold ({{ theme.fontWeight.medium }}).
 
 ## Text styles
 This set of standardized text styles should cover most needs, including

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sfgov-design-system",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "sfgov-design-system",
-      "version": "2.2.1",
+      "version": "2.2.2",
       "license": "MIT",
       "devDependencies": {
         "@11ty/eleventy": "^0.12.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sfgov-design-system",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "repository": "SFDigitalServices/design-system",
   "author": "City & County of San Francisco, California",
   "license": "MIT",

--- a/src/css/fonts.css
+++ b/src/css/fonts.css
@@ -1,3 +1,1 @@
-@import url('https://fonts.googleapis.com/css?family=Rubik:300,400,500&display=swap');
-@import url('https://fonts.googleapis.com/css?family=Roboto+Mono:400&display=swap');
-@import url('https://fonts.googleapis.com/css?family=Noto+Sans+TC:300,400,500&display=swap&subset=chinese-traditional');
+@import url('https://fonts.googleapis.com/css2?family=Rubik:wght@300;400;600&family=Noto+Sans+TC:wght@300;400;500&family=Roboto+Mono&display=swap');

--- a/src/tokens/colors.js
+++ b/src/tokens/colors.js
@@ -1,4 +1,4 @@
-const brightBlue = '#4f66ee'
+const brightBlue = '#495ed4'
 const sequential = {
   darkBlue: {
     7: '#0d1670',

--- a/src/tokens/typography.js
+++ b/src/tokens/typography.js
@@ -6,7 +6,8 @@ const fontFamily = {
 const fontWeight = {
   light: 300,
   regular: 400,
-  medium: 500
+  // TODO [>=3]: rename to "semibold" (or "bold"?) and alias to "medium"
+  medium: 600
 }
 
 module.exports = {


### PR DESCRIPTION
### 🐛 Bug fixes
- The `action` color token has been updated to match Figma (`#4f66ee` is now `#495ed4`) (#61)
- The `medium` font-weight value has been updated from `500` to `600` to reflect Figma values. (part of #66)

### 📖 Documentation
- In the typography intro, the font-weights we use are now specified (part of #66)
- Fonts are now pulled in at improved speeds ⚡  (described in #66)

### Pull requests
- [x] #61 
- [x] #66