### PR TITLE
Typography: set "medium" font-weight to 600

### DIFF
--- a/docs/_includes/head.njk
+++ b/docs/_includes/head.njk
@@ -7,6 +7,9 @@
 <meta charset="utf-8">
 <meta name="viewport" content="{{ meta.viewport | default('width=device-width,initial-scale=1') }}">
 <link rel="shortcut icon" href="https://sf.gov/themes/custom/sfgovpl/favicon.ico" type="image/vnd.microsoft.icon">
+{# these speed up Google Fonts requests considerably #}
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 {% for style in assets.styles %}
   {% if style.href %}
     <link href="{{ style.href }}"

--- a/docs/foundations/typography.md
+++ b/docs/foundations/typography.md
@@ -5,12 +5,13 @@ specimens:
 ---
 
 ## Introduction
-Our typeface is Rubik, which was designed by Hubert and Fischer in 2015 for
-Google Fonts. It is an open-source typeface that comes in 5 weights with
-Roman and Italic styles, and can be accessed for free through [Google
-Fonts][rubik].
+Our typeface is [Rubik], which was designed by Hubert and Fischer in 2015 for
+Google. It is an open-source typeface that comes in 5 weights with Roman and
+Italic styles, and is available for free from [Google Fonts].
 
-We are primarily using only 3 of Rubik’s weights: Light, Regular, and Semibold.
+We are primarily using only 3 of Rubik’s weights: Light
+({{ theme.fontWeight.light }}), Regular ({{ theme.fontWeight.regular }}), and
+Semibold ({{ theme.fontWeight.medium }}).
 
 ## Text styles
 This set of standardized text styles should cover most needs, including

--- a/src/css/fonts.css
+++ b/src/css/fonts.css
@@ -1,3 +1,1 @@
-@import url('https://fonts.googleapis.com/css?family=Rubik:300,400,600&display=swap');
-@import url('https://fonts.googleapis.com/css?family=Roboto+Mono:400&display=swap');
-@import url('https://fonts.googleapis.com/css?family=Noto+Sans+TC:300,400,500&display=swap&subset=chinese-traditional');
+@import url('https://fonts.googleapis.com/css2?family=Rubik:wght@300;400;600&family=Noto+Sans+TC:wght@300;400;500&family=Roboto+Mono&display=swap');

--- a/src/css/fonts.css
+++ b/src/css/fonts.css
@@ -1,3 +1,3 @@
-@import url('https://fonts.googleapis.com/css?family=Rubik:300,400,500&display=swap');
+@import url('https://fonts.googleapis.com/css?family=Rubik:300,400,600&display=swap');
 @import url('https://fonts.googleapis.com/css?family=Roboto+Mono:400&display=swap');
 @import url('https://fonts.googleapis.com/css?family=Noto+Sans+TC:300,400,500&display=swap&subset=chinese-traditional');

--- a/src/tokens/typography.js
+++ b/src/tokens/typography.js
@@ -6,6 +6,7 @@ const fontFamily = {
 const fontWeight = {
   light: 300,
   regular: 400,
+  // TODO [>=3]: rename to "semibold" (or "bold"?) and alias to "medium"
   medium: 600
 }
 

--- a/src/tokens/typography.js
+++ b/src/tokens/typography.js
@@ -6,7 +6,7 @@ const fontFamily = {
 const fontWeight = {
   light: 300,
   regular: 400,
-  medium: 500
+  medium: 600
 }
 
 module.exports = {


### PR DESCRIPTION
To get us in sync with the Figma type styles. I made a pixel-by-pixel comparison [in Figma](https://www.figma.com/file/EHpOV0EI4a0aU1ezShuYMu/Title-1-comparison?node-id=1%3A5), which shows how both the before and after **web** styles compare to the "Title/X-Large" style in Figma. ~What I get from this is that the web 500 font-weight is actually more similar to the SemiBold variant than 600, but I'm curious what @coreyhunt, @laurenajong, and @nlsfds think.~ We discussed this in Slack and agreed that 600 is the way to go.

I tweaked the [typography introduction](https://sfgov-design-system-pr-66.herokuapp.com/foundations/typography/#introduction) text and links a bit and inlined the numeric font weights from our theme. One thing that doing this highlights is that we currently refer to the semibold weight as `medium`, which means you use `text-medium` to set `font-weight: 600`. This is super confusing and we should change it in the next major version and provide guidance for migrating to the new name. (IMO, for the sake of consistency, we should refer to it as `semibold` throughout.)

I've also taken this opportunity to upgrade to the [v2 Google Fonts CSS API](https://developers.google.com/fonts/docs/css2) and added `<link rel=preload>` tags to our docs HTML as [Google suggests](https://web.dev/preload-critical-assets/).