### PR TITLE
feat(forms): design radio component

### DIFF
--- a/docs/components/forms/checkbox.md
+++ b/docs/components/forms/checkbox.md
@@ -57,7 +57,7 @@ We should probably come up with guidance about accessibility and disabled form e
 
 ## Fieldset
 
-Here's how we group together a set of chekboxes. Put in da `border-0` class on da `<fieldset>` to reset da default stylez.
+Two or more checkboxes should be grouped inside a `<fieldset>`. The `border-0` and `space-y-12` classes remove browser default styling and add vertical space between children.
 
 ```html
 <fieldset class="border-0 space-y-12">
@@ -93,9 +93,9 @@ Here's how we group together a set of chekboxes. Put in da `border-0` class on d
 Here are alts to the default checkbox configuration.
 ### Small groups
 
-The small checkbox groups are an option when the strings for choices are short and present better as a list of inline options. Use the `.small-checkbox-group` class on the wrapping element, with a `<div>` as container for each checkbox in the group.
+The small checkbox groups are an option when the strings for choices are short and present better as a list of inline options. Use the `.small-input-group` class on the wrapping element, with a `<div>` as container for each checkbox in the group.
 
-```html highlight="small-checkbox-group"
+```html highlight="small-input-group"
 <fieldset class="border-0 space-y-12">
   <div for="foo-input" class="block title-xs">
     Select the days that you’re open
@@ -106,7 +106,7 @@ The small checkbox groups are an option when the strings for choices are short a
   <div class="text-small text-slate-2">
     Select all that apply
   </div>
-  <div class="small-checkbox-group">
+  <div class="small-input-group">
     <div>
       <input type="checkbox" class="form-checkbox sr-only" id="checkbox-mon">
       <label class="vertical flex flex-wrap items-center p-12 gap-20" for="checkbox-mon">
@@ -151,7 +151,7 @@ The small checkbox groups are an option when the strings for choices are short a
 We allow for placement of the label horizontally (by default) and vertically (via placing the `.vertical` class on the `<label>`) relative to the checkbox input element. Labels should be placed to the right or above the input element.
 
 ```html highlight="vertical"
-<fieldset class="small-checkbox-group">
+<fieldset class="small-input-group">
   <div>
     <input type="checkbox" class="form-checkbox sr-only" id="checkbox-top">
     <label class="vertical flex flex-wrap items-center p-12 gap-20" for="checkbox-top">

--- a/docs/components/forms/radio-field.md
+++ b/docs/components/forms/radio-field.md
@@ -1,0 +1,171 @@
+---
+title: Radio Fields
+see_also:
+  - title: Figma
+    href: 'https://www.figma.com/file/nCDNClTAztpLol9l74QWSP/SF-Components?node-id=3861%3A3791'
+---
+
+## Introduction
+
+Here we will explain everything you could possibly need to know about the SF DesSys radio group component
+
+## Radio field component anatomy
+
+Check it out:
+
+```html highlight="(form-radio[-\w]*|radio-id)"
+<form>
+  <div>
+    <input type="radio" class="form-radio" id="radio-id" name="radio" value="radio">
+    <label for="radio-id" class="flex flex-wrap items-center p-12 gap-20">
+      <div class="form-radio-check"></div>
+      <span>This is the label</span>
+    </label>
+  </div>
+</form>
+```
+
+### Radio error state
+
+```html highlight="required"
+<form>
+  <div>
+    <input type="radio" class="form-radio" id="radio-id" name="radio" value="radio" required>
+    <label for="radio-id" class="flex flex-wrap items-center p-12 gap-20">
+      <div class="form-radio-check"></div>
+      <span>This is the label</span>
+    </label>
+  </div>
+</form>
+```
+
+### Radio disabled state
+
+We should probably come up with guidance about accessibility and disabled form elements. We might have to be particularly descriptive about _why_ a particular element is disabled within the context of a form.
+
+```html highlight="disabled"
+<form>
+  <div>
+    <input type="radio" class="form-radio" id="radio-id" name="radio" value="radio" disabled>
+    <label for="radio-id" class="flex flex-wrap items-center p-12 gap-20">
+      <div class="form-radio-check"></div>
+      <span>This is the label</span>
+    </label>
+  </div>
+</form>
+```
+
+## Radio fieldset
+
+Two or more radio inputs should be grouped inside a `<fieldset>`. The `border-0` and `space-y-12` classes remove browser default styling and add vertical space between children.
+
+```html
+<fieldset class="border-0 space-y-12">
+  <div for="foo-input" class="block title-xs">
+    Title 
+  </div>
+  <div id="foo-description">
+    Description
+  </div>
+  <div class="space-y-8">
+    <div class="text-small text-slate-2">
+      Select one
+    </div>
+    <div class="space-y-12">
+      {%- for i in range(4) %}
+        <div>
+          <input type="radio" class="form-radio" id="radio-{{ i }}" name="radio" value="radio">
+          <label for="radio-{{ i }}" class="flex flex-wrap items-center p-12 gap-20">
+            <div class="form-radio-check"></div>
+            <span>This is the label</span>
+          </label>
+        </div>
+      {%- endfor %}
+    </div>
+    <div class="text-small text-red-4">
+      Please select a fruit
+    </div>
+</fieldset>
+```
+
+## Radio field alts
+
+Here are alts to the default radio group configuration.
+
+### Small radio groups
+
+The small radio inputs groups are an option when the strings for choices are short and present better as a list of inline options. Use the `.small-input-group` class on the wrapping element, with a `<div>` as container for each radio group in the group.
+
+```html highlight="small-input-group"
+<fieldset class="border-0 space-y-12">
+  <div for="foo-input" class="block title-xs">
+    Select your favorite day
+  </div>
+  <div id="foo-description">
+    Please pick the day that suits you best.
+  </div>
+  <div class="text-small text-slate-2">
+    Select one
+  </div>
+  <div class="small-input-group">
+    <div>
+      <input type="radio" class="form-radio" id="radio-mon" name="radio" value="radio">
+      <label class="vertical flex flex-wrap items-center p-12 gap-20" for="radio-mon">
+        <span>Mon</span>
+        <div class="form-radio-check"></div>
+      </label>
+    </div>
+    <div>
+      <input type="radio" class="form-radio" id="radio-tues" name="radio" value="radio">
+      <label class="vertical flex flex-wrap items-center p-12 gap-20" for="radio-tues">
+        <span>Tues</span>
+        <div class="form-radio-check"></div>
+      </label>
+    </div>
+    <div>
+      <input type="radio" class="form-radio" id="radio-weds" name="radio" value="radio">
+      <label class="vertical flex flex-wrap items-center p-12 gap-20" for="radio-weds">
+        <span>Weds</span>
+        <div class="form-radio-check"></div>
+      </label>
+    </div>
+    <div>
+      <input type="radio" class="form-radio" id="radio-thurs" name="radio" value="radio">
+      <label class="vertical flex flex-wrap items-center p-12 gap-20" for="radio-thurs">
+        <span>Thurs</span>
+        <div class="form-radio-check"></div>
+      </label>
+    </div>
+    <div>
+      <input type="radio" class="form-radio" id="radio-fri" name="radio" value="radio">
+      <label class="vertical flex flex-wrap items-center p-12 gap-20" for="radio-fri">
+        <span>Fri</span>
+        <div class="form-radio-check"></div>
+      </label>
+    </div>
+  </div>
+</fieldset>
+```
+
+### Radio label positioning
+
+We allow for placement of the label horizontally (by default) and vertically (via placing the `.vertical` class on the `<label>`) relative to the radio input element. Labels should be placed to the right or above the input element.
+
+```html highlight="vertical"
+<fieldset class="small-input-group">
+  <div>
+    <input type="radio" class="form-radio" id="radio-top" name="radio" value="radio">
+    <label class="vertical flex flex-wrap items-center p-12 gap-20" for="radio-top">
+      <span>Top</span>
+      <div class="form-radio-check"></div>
+    </label>
+  </div>
+  <div>
+    <input type="radio" class="form-radio" id="radio-right" name="radio" value="radio">
+    <label for="radio-right" class="flex flex-wrap items-center p-12 gap-20">
+      <div class="form-radio-check"></div>
+      <span>Right</span>
+    </label>
+  </div>
+</fieldset>
+```

--- a/docs/components/forms/radio.md
+++ b/docs/components/forms/radio.md
@@ -1,5 +1,5 @@
 ---
-title: Radio Fields
+title: Radio buttons
 see_also:
   - title: Figma
     href: 'https://www.figma.com/file/nCDNClTAztpLol9l74QWSP/SF-Components?node-id=3861%3A3791'
@@ -16,7 +16,7 @@ Check it out:
 ```html highlight="(form-radio[-\w]*|radio-id)"
 <form>
   <div>
-    <input type="radio" class="form-radio" id="radio-id" name="radio" value="radio">
+    <input type="radio" class="form-radio" id="radio-id" name="radio" value="cool">
     <label for="radio-id" class="flex flex-wrap items-center p-12 gap-20">
       <div class="form-radio-check"></div>
       <span>This is the label</span>
@@ -30,7 +30,7 @@ Check it out:
 ```html highlight="required"
 <form>
   <div>
-    <input type="radio" class="form-radio" id="radio-id" name="radio" value="radio" required>
+    <input type="radio" class="form-radio" id="radio-id" name="radio" value="cool" required>
     <label for="radio-id" class="flex flex-wrap items-center p-12 gap-20">
       <div class="form-radio-check"></div>
       <span>This is the label</span>
@@ -46,7 +46,7 @@ We should probably come up with guidance about accessibility and disabled form e
 ```html highlight="disabled"
 <form>
   <div>
-    <input type="radio" class="form-radio" id="radio-id" name="radio" value="radio" disabled>
+    <input type="radio" class="form-radio" id="radio-id" name="radio" value="cool" disabled>
     <label for="radio-id" class="flex flex-wrap items-center p-12 gap-20">
       <div class="form-radio-check"></div>
       <span>This is the label</span>
@@ -74,7 +74,7 @@ Two or more radio inputs should be grouped inside a `<fieldset>`. The `border-0`
     <div class="space-y-12">
       {%- for i in range(4) %}
         <div>
-          <input type="radio" class="form-radio" id="radio-{{ i }}" name="radio" value="radio">
+          <input type="radio" class="form-radio" id="radio-{{ i }}" name="radio" value="cool">
           <label for="radio-{{ i }}" class="flex flex-wrap items-center p-12 gap-20">
             <div class="form-radio-check"></div>
             <span>This is the label</span>
@@ -109,35 +109,35 @@ The small radio inputs groups are an option when the strings for choices are sho
   </div>
   <div class="small-input-group">
     <div>
-      <input type="radio" class="form-radio" id="radio-mon" name="radio" value="radio">
+      <input type="radio" class="form-radio" id="radio-mon" name="radio" value="cool">
       <label class="vertical flex flex-wrap items-center p-12 gap-20" for="radio-mon">
         <span>Mon</span>
         <div class="form-radio-check"></div>
       </label>
     </div>
     <div>
-      <input type="radio" class="form-radio" id="radio-tues" name="radio" value="radio">
+      <input type="radio" class="form-radio" id="radio-tues" name="radio" value="cool">
       <label class="vertical flex flex-wrap items-center p-12 gap-20" for="radio-tues">
         <span>Tues</span>
         <div class="form-radio-check"></div>
       </label>
     </div>
     <div>
-      <input type="radio" class="form-radio" id="radio-weds" name="radio" value="radio">
+      <input type="radio" class="form-radio" id="radio-weds" name="radio" value="cool">
       <label class="vertical flex flex-wrap items-center p-12 gap-20" for="radio-weds">
         <span>Weds</span>
         <div class="form-radio-check"></div>
       </label>
     </div>
     <div>
-      <input type="radio" class="form-radio" id="radio-thurs" name="radio" value="radio">
+      <input type="radio" class="form-radio" id="radio-thurs" name="radio" value="cool">
       <label class="vertical flex flex-wrap items-center p-12 gap-20" for="radio-thurs">
         <span>Thurs</span>
         <div class="form-radio-check"></div>
       </label>
     </div>
     <div>
-      <input type="radio" class="form-radio" id="radio-fri" name="radio" value="radio">
+      <input type="radio" class="form-radio" id="radio-fri" name="radio" value="cool">
       <label class="vertical flex flex-wrap items-center p-12 gap-20" for="radio-fri">
         <span>Fri</span>
         <div class="form-radio-check"></div>
@@ -154,14 +154,14 @@ We allow for placement of the label horizontally (by default) and vertically (vi
 ```html highlight="vertical"
 <fieldset class="small-input-group">
   <div>
-    <input type="radio" class="form-radio" id="radio-top" name="radio" value="radio">
+    <input type="radio" class="form-radio" id="radio-top" name="radio" value="cool">
     <label class="vertical flex flex-wrap items-center p-12 gap-20" for="radio-top">
       <span>Top</span>
       <div class="form-radio-check"></div>
     </label>
   </div>
   <div>
-    <input type="radio" class="form-radio" id="radio-right" name="radio" value="radio">
+    <input type="radio" class="form-radio" id="radio-right" name="radio" value="cool">
     <label for="radio-right" class="flex flex-wrap items-center p-12 gap-20">
       <div class="form-radio-check"></div>
       <span>Right</span>

--- a/docs/components/forms/radio.md
+++ b/docs/components/forms/radio.md
@@ -9,15 +9,15 @@ see_also:
 
 Here we will explain everything you could possibly need to know about the SF DesSys radio group component
 
-## Radio field component anatomy
+## Radio button component anatomy
 
-Check it out:
+Radio buttons are made up of three constitutive parts: an input, a label, and a checkmark.
 
 ```html highlight="(form-radio[-\w]*|radio-id)"
 <form>
   <div>
     <input type="radio" class="form-radio" id="radio-id" name="radio" value="cool">
-    <label for="radio-id" class="flex flex-wrap items-center p-12 gap-20">
+    <label for="radio-id" class="flex flex-wrap p-12 gap-20">
       <div class="form-radio-check"></div>
       <span>This is the label</span>
     </label>
@@ -25,13 +25,19 @@ Check it out:
 </form>
 ```
 
+The label acts as a wrapper for the checkmark and the label text. The `flex` utility is used to display elements side-by-side. In this example we use the `p-12` utility to expand the hover area and `gap-20` to create uniform spacing between the checkmark and label text.
+
+A label is **required**, and **must** be associated with the input either as a `<label>` with the input's `id` in its `for` attribute, or with its own `id` attribute referenced by the input's `aria-labelledby`.
+
 ### Radio error state
+
+Fields that are required should have the `required` attribute or `aria-invalid="true"` when the form is invalid.
 
 ```html highlight="required"
 <form>
   <div>
     <input type="radio" class="form-radio" id="radio-id" name="radio" value="cool" required>
-    <label for="radio-id" class="flex flex-wrap items-center p-12 gap-20">
+    <label for="radio-id" class="flex flex-wrap p-12 gap-20">
       <div class="form-radio-check"></div>
       <span>This is the label</span>
     </label>
@@ -41,13 +47,15 @@ Check it out:
 
 ### Radio disabled state
 
+Fields that are disabled should have the `disabled` attribute or `aria-disabled="true"` and should not allow mouse or keyboard interaction.
+
 We should probably come up with guidance about accessibility and disabled form elements. We might have to be particularly descriptive about _why_ a particular element is disabled within the context of a form.
 
 ```html highlight="disabled"
 <form>
   <div>
     <input type="radio" class="form-radio" id="radio-id" name="radio" value="cool" disabled>
-    <label for="radio-id" class="flex flex-wrap items-center p-12 gap-20">
+    <label for="radio-id" class="flex flex-wrap p-12 gap-20">
       <div class="form-radio-check"></div>
       <span>This is the label</span>
     </label>
@@ -58,6 +66,8 @@ We should probably come up with guidance about accessibility and disabled form e
 ## Radio fieldset
 
 Two or more radio inputs should be grouped inside a `<fieldset>`. The `border-0` and `space-y-12` classes remove browser default styling and add vertical space between children.
+
+A group of radio buttons **must** have a matching `name` value to associate them. In this example, each input has the attribute `name="radio"`.
 
 ```html
 <fieldset class="border-0 space-y-12">
@@ -75,7 +85,7 @@ Two or more radio inputs should be grouped inside a `<fieldset>`. The `border-0`
       {%- for i in range(4) %}
         <div>
           <input type="radio" class="form-radio" id="radio-{{ i }}" name="radio" value="cool">
-          <label for="radio-{{ i }}" class="flex flex-wrap items-center p-12 gap-20">
+          <label for="radio-{{ i }}" class="flex flex-wrap p-12 gap-20">
             <div class="form-radio-check"></div>
             <span>This is the label</span>
           </label>
@@ -110,35 +120,35 @@ The small radio inputs groups are an option when the strings for choices are sho
   <div class="small-input-group">
     <div>
       <input type="radio" class="form-radio" id="radio-mon" name="radio" value="cool">
-      <label class="vertical flex flex-wrap items-center p-12 gap-20" for="radio-mon">
+      <label class="vertical flex flex-wrap p-12 gap-20" for="radio-mon">
         <span>Mon</span>
         <div class="form-radio-check"></div>
       </label>
     </div>
     <div>
       <input type="radio" class="form-radio" id="radio-tues" name="radio" value="cool">
-      <label class="vertical flex flex-wrap items-center p-12 gap-20" for="radio-tues">
+      <label class="vertical flex flex-wrap p-12 gap-20" for="radio-tues">
         <span>Tues</span>
         <div class="form-radio-check"></div>
       </label>
     </div>
     <div>
       <input type="radio" class="form-radio" id="radio-weds" name="radio" value="cool">
-      <label class="vertical flex flex-wrap items-center p-12 gap-20" for="radio-weds">
+      <label class="vertical flex flex-wrap p-12 gap-20" for="radio-weds">
         <span>Weds</span>
         <div class="form-radio-check"></div>
       </label>
     </div>
     <div>
       <input type="radio" class="form-radio" id="radio-thurs" name="radio" value="cool">
-      <label class="vertical flex flex-wrap items-center p-12 gap-20" for="radio-thurs">
+      <label class="vertical flex flex-wrap p-12 gap-20" for="radio-thurs">
         <span>Thurs</span>
         <div class="form-radio-check"></div>
       </label>
     </div>
     <div>
       <input type="radio" class="form-radio" id="radio-fri" name="radio" value="cool">
-      <label class="vertical flex flex-wrap items-center p-12 gap-20" for="radio-fri">
+      <label class="vertical flex flex-wrap p-12 gap-20" for="radio-fri">
         <span>Fri</span>
         <div class="form-radio-check"></div>
       </label>
@@ -155,14 +165,14 @@ We allow for placement of the label horizontally (by default) and vertically (vi
 <fieldset class="small-input-group">
   <div>
     <input type="radio" class="form-radio" id="radio-top" name="radio" value="cool">
-    <label class="vertical flex flex-wrap items-center p-12 gap-20" for="radio-top">
+    <label class="vertical flex flex-wrap p-12 gap-20" for="radio-top">
       <span>Top</span>
       <div class="form-radio-check"></div>
     </label>
   </div>
   <div>
     <input type="radio" class="form-radio" id="radio-right" name="radio" value="cool">
-    <label for="radio-right" class="flex flex-wrap items-center p-12 gap-20">
+    <label for="radio-right" class="flex flex-wrap p-12 gap-20">
       <div class="form-radio-check"></div>
       <span>Right</span>
     </label>

--- a/src/css/components/forms.css
+++ b/src/css/components/forms.css
@@ -15,17 +15,25 @@
   }
 }
 
-.form-checkbox {
+.form-checkbox, .form-radio {
   @apply absolute outline-none w-0 h-0;
 
   & ~ label {
     @apply rounded cursor-pointer;
     @apply rounded-4 border-2 border-solid border-white hocus:border-slate-2;
-  }
 
-  & ~ label .form-checkbox-check {
-    @apply text-transparent;
-    @apply w-24 h-24 p-4 rounded-4 bg-slate-1 border-1 border-solid border-slate;
+    .form-checkbox-check, .form-radio-check {
+      @apply text-transparent;
+      @apply w-24 h-24 p-4 bg-slate-1 border-1 border-solid border-slate-2;
+    }
+    
+    .form-checkbox-check {
+      @apply rounded-4;
+    }
+
+    .form-radio-check {
+      @apply rounded-full;
+    }
   }
 
   /* TODO: much of the following could be done with the `peer-` variants in tailwind 3.0.0 */
@@ -47,6 +55,10 @@
       .form-checkbox-check {
         @apply text-white bg-slate-3 border-transparent !important;
       }
+      
+      .form-radio-check {
+        @apply bg-white border-6 border-slate-3;
+      }
     }
   }
 
@@ -63,9 +75,9 @@
         @apply border-red-3;
       }
 
-      .form-checkbox-check {
+      .form-checkbox-check, .form-radio-check {
         @apply bg-white;
-        @apply border-1 border-solid rounded-4 border-red-3;
+        @apply border-1 border-solid border-red-3;
       }    
     }
   }
@@ -75,18 +87,19 @@
   &[aria-disabled=true] {
     ~ label {
       @apply border-0;
+      @apply text-grey-3;
       @apply hocus:border-none;
       @apply pointer-events-none;
 
-      .form-checkbox-check {
+      .form-checkbox-check, .form-radio-check {
         @apply bg-grey-1;
-        @apply border-1 border-solid rounded-4 border-grey-2;
+        @apply border-1 border-solid border-grey-2;
       }
     }
   }
 }
 
-.small-checkbox-group {
+.small-input-group {
   @apply flex space-x-8;
   @apply border-0;
 
@@ -98,7 +111,7 @@
     @apply inline-flex items-center;
   }
 
-  .form-checkbox {
+  .form-checkbox, .form-radio {
     &:checked {
       ~ label {
         @apply bg-none;

--- a/src/theme.js
+++ b/src/theme.js
@@ -35,7 +35,8 @@ module.exports = {
     DEFAULT: '8px',
     0: '0',
     2: '2px',
-    4: '4px'
+    4: '4px',
+    full: '9999px'
   },
   borderWidth: {
     DEFAULT: '3px',
@@ -43,7 +44,8 @@ module.exports = {
     1: '1px',
     2: '2px',
     3: '3px',
-    4: '4px'
+    4: '4px',
+    6: '6px'
   },
   gap: {
     ...spacing


### PR DESCRIPTION
This adds the radio button component based on the current [figma](https://www.figma.com/file/nCDNClTAztpLol9l74QWSP/SF-Components?node-id=3861%3A3791) designs.

The implementation is similar in approach to the checkbox (#72) but adds two component classes:
- `.form-radio` which reuses the `.form-checkbox` classes but distinguishes parent elements for clarity (this might be unnecessary, we could make a more generic class name for both)
- `.form-radio-check` which adds styles for the radio button visual and its toggle states.

The latter class required adding two new utilities: `border-6` (for creating the 'checked' state) and `rounded-full` (to make a circle).