### PR TITLE
Fix JavaScript MIME type

### DIFF
--- a/static.json
+++ b/static.json
@@ -1,4 +1,9 @@
 {
+  "https_only": true,
   "root": "public",
-  "https_only": true
+  "headers": {
+    "**/*.js": {
+      "Content-type": "text/javascript"
+    }
+  }
 }


### PR DESCRIPTION
As noted in heroku/heroku-buildpack-static#232, the buildpack we're using sends the wrong `Content-type` header for `.js` files. ~This _should_ fix it.~ This fixes it.