### PR TITLE
Fix <sfgov-icon> in Docusaurus/React

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "shellcheck": "^1.1.0",
         "stylelint": "^14.8.4",
         "stylelint-config-standard": "^25.0.0",
-        "wireit": "^0.4.3"
+        "wireit": "^0.7.1"
       },
       "engines": {
         "node": ">=14.x",
@@ -20950,12 +20950,9 @@
       "license": "MIT"
     },
     "node_modules/wireit": {
-      "version": "0.4.3",
-      "license": "Apache-2.0",
-      "workspaces": [
-        "vscode-extension",
-        "website"
-      ],
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/wireit/-/wireit-0.7.1.tgz",
+      "integrity": "sha512-TwuKae0aHk06DZ2omLW6YF4Y74YxCyuRCcsjZMm+cUPRXhvxAU2JhYyuCvD9wIALWK+cQUpB9GjeRFPRAbKsdw==",
       "dependencies": {
         "braces": "^3.0.2",
         "chokidar": "^3.5.3",
@@ -34413,7 +34410,9 @@
       "version": "2.0.0"
     },
     "wireit": {
-      "version": "0.4.3",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/wireit/-/wireit-0.7.1.tgz",
+      "integrity": "sha512-TwuKae0aHk06DZ2omLW6YF4Y74YxCyuRCcsjZMm+cUPRXhvxAU2JhYyuCvD9wIALWK+cQUpB9GjeRFPRAbKsdw==",
       "requires": {
         "braces": "^3.0.2",
         "chokidar": "^3.5.3",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,6 @@
     "shellcheck": "^1.1.0",
     "stylelint": "^14.8.4",
     "stylelint-config-standard": "^25.0.0",
-    "wireit": "^0.4.3"
+    "wireit": "^0.7.1"
   }
 }

--- a/packages/sfgov-design-system/package.json
+++ b/packages/sfgov-design-system/package.json
@@ -42,7 +42,7 @@
       "clean": true,
       "files": [
         "src/css/**/*.css",
-        "*.config.js"
+        "*.config.*"
       ],
       "output": [
         "dist/css/**/*.css"
@@ -53,30 +53,30 @@
       "dependencies": [
         "build-css"
       ],
-      "files": [
-        "src/css/**/*.css",
-        "*.config.js"
-      ],
       "output": [
         "dist/css/css-manifest.json"
       ]
     },
     "build-js": {
       "command": "rollup -c",
+      "clean": true,
       "files": [
         "package.json",
-        "src/js/**/*.js",
-        "*.js"
+        "src/**",
+        "*config.*"
       ],
       "output": [
         "dist/**/*.js",
-        "dist/js/**/*.mjs"
+        "dist/**/*.mjs"
       ]
     },
     "build-icons": {
       "command": "scripts/build-icons.js",
       "files": [
         "src/icons/**/*.{js,json,svg}"
+      ],
+      "output": [
+        "dist/icons/*.svg"
       ]
     },
     "build-manifest": {

--- a/packages/sfgov-design-system/src/icons/index.js
+++ b/packages/sfgov-design-system/src/icons/index.js
@@ -30,7 +30,7 @@ export function render (symbol, props = {}) {
 
 const observedAttributes = ['symbol', 'width', 'height']
 
-export class SFGovIcon extends window.HTMLElement {
+export class SFGovIcon extends HTMLElement {
   static get observedAttributes () {
     return observedAttributes
   }
@@ -62,7 +62,7 @@ export class SFGovIcon extends window.HTMLElement {
   }
 
   get svg () {
-    return this.__svg
+    return this.__svg || this.querySelector('svg')
   }
 
   set svg (node) {

--- a/website/src/components/BigLink.js
+++ b/website/src/components/BigLink.js
@@ -1,12 +1,13 @@
 import React from 'react'
 import Link from '@docusaurus/Link'
 import PropTypes from 'prop-types'
+import SFGovIcon from './SFGovIcon'
 
 const BigLink = ({ link, label }) => {
   return (
     <Link to={link} className='flex items-center font-regular text-action no-underline hover:text-slate-4 hocus:bg-grey-1' style={{ padding: '8px 12px', width: 'fit-content', borderRadius: '20px' }}>
       <p className='m-0 mr-4'>{label}</p>
-      <sfgov-icon symbol='chevron-right'></sfgov-icon>
+      <SFGovIcon symbol='chevron-right' />
     </Link>
   )
 }

--- a/website/src/components/ColorSwatch.js
+++ b/website/src/components/ColorSwatch.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import BrowserOnly from '@docusaurus/BrowserOnly'
 import { CopyToClipboard } from 'react-copy-to-clipboard'
 import clsx from 'clsx'
+import SFGovIcon from './SFGovIcon'
 
 export default function ColorSwatch ({ value, label, addBorder, className, children, ...rest }) {
   const [copied, setCopied] = useState()
@@ -35,7 +36,7 @@ export default function ColorSwatch ({ value, label, addBorder, className, child
                 <div className='flex justify-between items-center font-mono'>
                   {value}
                   <div className={isHover ? 'inherit' : 'text-white'}>
-                  <sfgov-icon symbol='clipboard'></sfgov-icon>
+                  <SFGovIcon symbol='clipboard' />
                   </div>
                 </div>
                 {children}

--- a/website/src/components/DoDont.jsx
+++ b/website/src/components/DoDont.jsx
@@ -2,6 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import clsx from 'clsx'
 import EncapsulatedStyleRoot from './EncapsulatedStyleRoot'
+import SFGovIcon from './SFGovIcon'
 
 /**
  * Use the <DoDont> component to display "do" and "don't" examples with
@@ -50,7 +51,7 @@ function Box ({ borderClass, iconSymbol, iconClass, children, reasons, reasonsCl
           bg-white border-2 border-solid
           flex items-center justify-center
         `, borderClass, iconClass)}>
-          {iconSymbol && <sfgov-icon symbol={iconSymbol} width={16} height={16} />}
+          {iconSymbol && <SFGovIcon symbol={iconSymbol} width={16} height={16} />}
         </div>
       </div>
       <ul className={clsx('m-0 mb-20 pl-28 lg:mb-0 border-0 border-t-4 border-solid', borderClass, reasonsClass)}>

--- a/website/src/components/HomepageFeatures/Feature.js
+++ b/website/src/components/HomepageFeatures/Feature.js
@@ -1,6 +1,7 @@
 import React, { useState } from 'react'
 import PropTypes from 'prop-types'
 import clsx from 'clsx'
+import SFGovIcon from '../SFGovIcon'
 
 const Feature = (props) => {
   const [isHover, setIsHover] = useState(false)
@@ -24,7 +25,7 @@ const Feature = (props) => {
         )}
       </div>
       <div className='w-full text-right text-action group-hocus:text-white'>
-        <sfgov-icon symbol='arrow-right' aria-hidden='true' role='img' />
+        <SFGovIcon symbol='arrow-right' aria-hidden='true' role='img' />
       </div>
     </a>
   )

--- a/website/src/components/IconSample.js
+++ b/website/src/components/IconSample.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import BrowserOnly from '@docusaurus/BrowserOnly'
 import { CopyToClipboard } from 'react-copy-to-clipboard'
 import clsx from 'clsx'
+import SFGovIcon from './SFGovIcon'
 
 export default function IconSample ({
   iconInfo
@@ -17,7 +18,7 @@ export default function IconSample ({
   return (
     <div className={clsx('flex flex-wrap w-1/4')}>
       <div className={'h-100 w-full border-grey-2 dark:border-grey-dark border-1 border-solid flex items-center justify-center'}>
-        <sfgov-icon symbol={iconInfo}></sfgov-icon>
+        <SFGovIcon symbol={iconInfo} />
       </div>
       <div className='w-full'>
         <BrowserOnly>
@@ -35,7 +36,7 @@ export default function IconSample ({
                 <div className='flex justify-between items-center font-mono' style={{ textTransform: 'lowercase' }}>
                   {iconInfo}
                   <div className={isHover ? 'inherit' : 'text-white'}>
-                    <sfgov-icon symbol='clipboard'></sfgov-icon>
+                    <SFGovIcon symbol='clipboard' />
                   </div>
                 </div>
 

--- a/website/src/components/SFGovIcon.js
+++ b/website/src/components/SFGovIcon.js
@@ -1,0 +1,12 @@
+import React, { useMemo } from 'react'
+
+/**
+ * This is a workaround for re-rendered custom elements that ignores children
+ * and memoizes the return value.
+ * 
+ * @param {React.PropsWithoutRef} props 
+ * @returns {JSX.Element}
+ */
+export default function SFGovIcon ({ children, ...props }) {
+  return useMemo(() => (<sfgov-icon {...props} />), [props])
+}

--- a/website/src/components/SFGovIcon.js
+++ b/website/src/components/SFGovIcon.js
@@ -1,12 +1,18 @@
-import React, { useMemo } from 'react'
+import React, { useLayoutEffect, useRef } from 'react'
+import useIsBrowser from '@docusaurus/useIsBrowser'
 
 /**
- * This is a workaround for re-rendered custom elements that ignores children
- * and memoizes the return value.
- * 
- * @param {React.PropsWithoutRef} props 
- * @returns {JSX.Element}
+ * This is a workaround for custom elements that get their
+ * <svg> contents blown away by React. We use a callback in
+ * useLayoutEffect() to force the SFGovIcon instance to re-render.
  */
-export default function SFGovIcon ({ children, ...props }) {
-  return useMemo(() => (<sfgov-icon {...props} />), [props])
+export default function SFGovIconWrapper (props) {
+  const ref = useRef()
+  const isBrowser = useIsBrowser()
+  useLayoutEffect(() => {
+    if (isBrowser && ref.current && window?.customElements?.get('sfgov-icon')) {
+      ref.current.render()
+    }
+  }, [isBrowser, ref, props])
+  return <sfgov-icon ref={ref} {...props} />
 }

--- a/website/src/components/TailwindDoc/tailwindSearchBar.js
+++ b/website/src/components/TailwindDoc/tailwindSearchBar.js
@@ -2,6 +2,7 @@ import React, { useRef } from 'react'
 import PropTypes from 'prop-types'
 import clsx from 'clsx'
 import { dispatch } from 'use-bus'
+import SFGovIcon from '../SFGovIcon'
 
 const twSearchBar = (props) => {
   const searchString = useRef(null)
@@ -10,7 +11,7 @@ const twSearchBar = (props) => {
     <div className='flex w-full justify-between mb-12'>
       <div className='lg:w-1/2 xl:w-1/4 xl:max-w-sm'>
         <div className='absolute h-40 flex pl-12 text-slate-3'>
-          <sfgov-icon symbol='search' />
+          <SFGovIcon symbol='search' />
         </div>
         <input
           className='rounded bg-slate-1 h-40 w-full px-40 border-2 border-solid border-slate-1 focus:bg-white hocus:border-slate-3 dark:text-black'

--- a/website/src/pages/index.jsx
+++ b/website/src/pages/index.jsx
@@ -3,6 +3,7 @@ import clsx from 'clsx'
 import Layout from '@theme/Layout'
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext'
 import HomepageFeatures from '@site/src/components/HomepageFeatures'
+import SFGovIcon from '../components/SFGovIcon'
 const { landingDesc } = require('../../constants')
 
 function HomepageHeader () {
@@ -19,7 +20,7 @@ function HomepageHeader () {
       <div className='w-full flex justify-center'>
         <a href='develop/install' className='btn flex gap-8 no-underline max-w-max hocus:text-white'>
           <span>Get started</span>
-          <sfgov-icon symbol='arrow-right'></sfgov-icon>
+          <SFGovIcon symbol='arrow-right' />
         </a>
       </div>
     </header>

--- a/website/src/theme/Playground/index.js
+++ b/website/src/theme/Playground/index.js
@@ -8,6 +8,7 @@ import BrowserOnly from '@docusaurus/BrowserOnly'
 import { usePrismTheme } from '@docusaurus/theme-common'
 import EncapsulatedStyleRoot from '../../components/EncapsulatedStyleRoot'
 import styles from './styles.module.css'
+import SFGovIcon from '../../components/SFGovIcon'
 
 function Header ({ as: Component = 'div', className, ...rest }) {
   return <Component className={clsx(styles.playgroundHeader, className)} {...rest} />
@@ -71,7 +72,7 @@ function EditorWithHeader ({ open: defaultOpen = true }) {
           description='The live editor label of the live codeblocks'>
           Code editor
         </Translate>
-        <sfgov-icon
+        <SFGovIcon
           symbol={open ? 'chevron-down' : 'chevron-right'}
           width='16' height='16'
         />


### PR DESCRIPTION
My first attempt at fixing this was to use [memoization](https://nickymeuleman.netlify.app/blog/react-memo) as a workaround to [skip child rendering](https://javascript.plainenglish.io/can-usememo-skip-a-child-render-94e61f5ad981), but I didn't have much luck with that approach. Instead, I went with a [useLayoutEffect](https://reactjs.org/docs/hooks-reference.html#uselayouteffect) hook that forcibly re-renders the icon.

The first time I viewed [the home page](https://sfgov-design-system-pr-106.herokuapp.com/) it glitched a bit, but I can't get it to do that again, even in an incognito window. So I think it's working correctly now!