### PR TITLE
📝 Add Tokens documentation, TokenList docs component

### DIFF
--- a/website/docs/libraries/tokens.mdx
+++ b/website/docs/libraries/tokens.mdx
@@ -1,0 +1,36 @@
+---
+title: Tokens
+---
+
+import allTokens from 'sfgov-design-system/src/tokens'
+import InlineSwatch from '@site/src/components/InlineSwatch'
+import TokenList, { FontSizeValue } from '@site/src/components/TokenList'
+
+These are all of the values defined in <GitHubFileLink path='packages/sfgov-design-system/src/tokens'>our tokens</GitHubFileLink>.
+
+
+## Color
+
+<TokenList field='colors' value={InlineSwatch} />
+
+## Typography
+
+### Font family
+<TokenList field='fontFamily' />
+
+### Font size
+<TokenList field='fontSize' value={FontSizeValue} />
+
+### Font weight
+<TokenList field='fontWeight' />
+
+### Letter spacing
+<TokenList field='letterSpacing' />
+
+## Whitespace
+
+<TokenList field='spacing' />
+
+## Breakpoints
+
+<TokenList field='breakpoints' />

--- a/website/src/components/TokenList.jsx
+++ b/website/src/components/TokenList.jsx
@@ -1,0 +1,92 @@
+import React from 'react'
+import tokens from 'sfgov-design-system/src/tokens'
+
+/**
+ * 
+ * @param {{ field: string, value?: React.Component } & React.ComponentProps<'table'>} props 
+ * @returns {JSX.Element}
+ */
+export default function TokenList ({ field, value: Value = JSONFormattedValue, ...rest }) {
+  const values = flatten(tokens[field] || {}, field)
+  return (
+    <table {...rest}>
+      <thead>
+        <tr>
+          <th>Token</th>
+          <th>Value</th>
+        </tr>
+      </thead>
+      <tbody>
+        {values.map(({ key, value }) => (
+          <tr key={key}>
+            <td><code>{key}</code></td>
+            <td><Value value={value} /></td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  )
+}
+
+/**
+ * 
+ * @param {object} obj 
+ * @param  {...string} prefixes 
+ * @returns {{ key: string, value: any }[]}
+ */
+function flatten (obj, ...prefixes) {
+  return Object.entries(obj)
+    .flatMap(([key, value]) => {
+      const path = [...prefixes, key].filter(Boolean)
+      return shouldNest(value)
+        ? flatten(value, ...path)
+        : {
+            key: path.join('.'),
+            value
+          }
+    })
+    .sort((a, b) => a.key.localeCompare(b.key))
+}
+
+/**
+ * 
+ * @param {any} value 
+ * @returns {boolean}
+ */
+function shouldNest (value) {
+  return (value instanceof Object) && !Array.isArray(value)
+}
+
+/**
+ * 
+ * @param {React.ComponentProps<'code'>} param0 
+ * @returns 
+ */
+function JSONFormattedValue ({ value, ...props }) {
+  return <code {...props}>{JSON.stringify(value)}</code>
+}
+
+/**
+ * @param {{ value: any } & React.ComponentProps<'a' | JSONFormattedValue>} param0 
+ * @returns {JSX.Element}
+ */
+export function FontSizeValue ({ value, ...props }) {
+  if (Array.isArray(value)) {
+    const [fontSize, rest] = value
+    const { lineHeight, letterSpacing } = (typeof rest === 'string')
+      ? { lineHeight: rest }
+      : rest
+    return <dl className='m-0 grid grid-cols-2' {...props}>
+      {
+        Object.entries({ fontSize, letterSpacing, lineHeight })
+          .filter(([key, value]) => value)
+          .map(([key, value]) => <>
+            <dt><code>{key}:</code></dt>
+            <dd><JSONFormattedValue value={value} /></dd>
+          </>)
+      }
+    </dl>
+  } else {
+    return <JSONFormattedValue value={value} {...props} />
+  }
+}


### PR DESCRIPTION
This adds a [design token library page](https://sfgov-design-system-pr-114.herokuapp.com/libraries/tokens) at `/libraries/tokens` that catalogs the current set of tokens powering our Tailwind theme. Colors are rendered with `<InlineSwatch>`, and all other values are formatted as JSON—with one exception: `fontSize` tokens are formatted in a more human-friendly format than Tailwind's [supported shorthand](https://v2.tailwindcss.com/docs/font-size#providing-a-default-line-height) for including `lineHeight` and `letterSpacing`.

<img width="478" alt="image" src="https://user-images.githubusercontent.com/113896/188219939-0a8f64be-7fbc-45f9-96dc-0474b8744766.png">

<img width="532" alt="image" src="https://user-images.githubusercontent.com/113896/188219986-18b78f30-15f2-4727-86d0-9c82ebc308e3.png">

<img width="272" alt="image" src="https://user-images.githubusercontent.com/113896/188220021-b942b967-70aa-4360-bbe8-7e334dd6c808.png">
