### PR TITLE
BREAKING CHANGE: update breakpoints, add xs + sm

### DIFF
--- a/packages/sfgov-design-system/src/tokens/breakpoints.js
+++ b/packages/sfgov-design-system/src/tokens/breakpoints.js
@@ -1,5 +1,8 @@
+// See: <https://sfgovdt.jira.com/browse/DESSYS-133?focusedCommentId=72274>
 module.exports = {
-  md: '420px',
-  lg: '768px',
-  xl: '1090px'
+  xs: '375px',
+  sm: '640px',
+  md: '768px',
+  lg: '1024px',
+  xl: '1280px'
 }


### PR DESCRIPTION
This PR implements @coreyhunt's suggested breakpoints in DESSYS-133. It's a breaking change because it modifies existing breakpoints. Here's how it will shake out, version-wise:

name | now (>=3) | 2.x
:--- | :--- | :---
`xs` | `375px`
`sm` | `640px`
`md` | `768px` | `420px`
`lg` | `1024px` | `768px`
`xl` | `1280px` | `1090px`

In other words, all of the old breakpoints are now larger, with `md` growing to `lg`'s old size. The following breakpoints are new. I made [this CodePen](https://codepen.io/shawnbot/pen/dyeLaoQ) to show the differences:

<img width="1280" alt="image" src="https://user-images.githubusercontent.com/113896/196299871-5f0a90f8-8239-4aa7-8dc2-f32c8c82f656.png">
