### PR TITLE
add section and tile components for page stories

### DIFF
--- a/storybook/src/ContactSection.jsx
+++ b/storybook/src/ContactSection.jsx
@@ -1,0 +1,49 @@
+import React from 'react'
+import { TileSection } from './Tile'
+import Section from './Section'
+import SectionTitle from './SectionTitle'
+
+export const ContactSection = args =>
+  <Section>
+    <SectionTitle>Contact</SectionTitle>
+    <ContactContent {...args} />
+  </Section>
+
+const ContactContent = ({ address, phone, email }) =>
+  <TileSection>
+    {address &&
+      <div className='flex items-start'>
+        <sfgov-icon symbol='location' class='pr-20' />
+        <div>
+          <h3 className='mt-0'>{address.title}</h3>
+          <div>{address.address_line1}</div>
+          <div>{address.address_line2}</div>
+          <div>{`${address.locality}, ${address.administrative_area} ${address.postal_code}`}</div>
+          <div className='bg-grey-2 h-100 w-100 mt-40 mb-20 p-20 rounded text-center'>A map will go here</div>
+          <a href='https://www.google.com/maps/dir/?api=1&amp;destination=1+Dr.+Carlton+B.+Goodlett+Place%2CCity+Hall+Room+362%2C+San+Francisco%2CCA+94102' target='_blank' rel='noreferrer'>Get directions</a>
+        </div>
+      </div>
+    }
+    {!!phone?.length &&
+      <div className='flex items-start'>
+        <sfgov-icon symbol='phone' class='pr-20'/>
+        {phone.map(p =>
+          <div key={p.tel}>
+            <h3 className='mt-0'>Phone</h3>
+            {p.owner && <div>{p.owner}</div>}
+            <a href={`tel:${p.tel}`}>{p.tel}</a>
+          </div>
+        )}
+      </div>
+    }
+    {email &&
+      <div className='flex items-start'>
+        <sfgov-icon symbol='mail' class='pr-20'/>
+        <div>
+          <h3 className='mt-0'>Email</h3>
+            {email.owner && <div>{email.owner}</div>}
+          <a href={`mailto:${email.email}`}>{email.email}</a>
+        </div>
+      </div>
+    }
+  </TileSection>

--- a/storybook/src/Section.jsx
+++ b/storybook/src/Section.jsx
@@ -1,0 +1,25 @@
+import React from 'react'
+import tw from 'tailwind-styled-components'
+import { withVariants } from './utils'
+
+const SectionContainer = withVariants(tw.section`
+  py-80
+`, {
+  lightblue: { className: 'bg-blue-1 text-slate' },
+  darkblue: { className: 'bg-blue-dark text-white' },
+  yellow: { className: 'bg-yellow-1 text-slate' },
+  white: { className: 'bg-white text-slate' }
+}, 'white')
+
+const ResponsiveContainer = tw.div`
+  responsive-container
+`
+
+const Section = ({ children, ...props }) =>
+  <SectionContainer {...props}>
+    <ResponsiveContainer>
+      {children}
+    </ResponsiveContainer>
+  </SectionContainer>
+
+export default Section

--- a/storybook/src/SectionTitle.jsx
+++ b/storybook/src/SectionTitle.jsx
@@ -1,0 +1,9 @@
+import tw from 'tailwind-styled-components'
+
+const SectionTitle = tw.h2`
+  title-xl
+  mt-0
+  mb-40
+`
+
+export default SectionTitle

--- a/storybook/src/Tile.jsx
+++ b/storybook/src/Tile.jsx
@@ -1,0 +1,59 @@
+import React from 'react'
+import tw from 'tailwind-styled-components'
+
+export const TileSection = tw.div`
+  grid
+  grid-cols-1
+  lg:grid-cols-3
+  gap-20
+  mb-60
+`
+
+const TileContainer = tw.div`
+  rounded
+  flex
+  justify-between
+  overflow-hidden
+  flex-col
+  md:flex-row
+`
+
+const TextWrapper = tw.div`
+  p-20
+`
+
+const TileTitle = tw.div`
+  font-medium
+  mb-20
+`
+
+const TileImage = tw.img`
+  ${props => props.variant === 'Event' ? 'rounded-t' : 'pl-8 rounded-r w-1/3'}
+`
+
+export const NewsTile = ({ title, body, img }) =>
+  <TileContainer $as='a' className='text-slate bg-yellow-3 hover:bg-yellow-4'>
+    <TextWrapper>
+      <TileTitle>{title}</TileTitle>
+      <div>{body}</div>
+    </TextWrapper>
+    {img && <TileImage src={img} style={{ objectFit: 'cover' }} />}
+  </TileContainer>
+
+// export const EventTile = ({ title, body }) => {}
+
+export const FeatureTile = ({ title, body }) =>
+  <TileContainer $as='a' className='text-white bg-purple-3 hover:bg-purple-4'>
+    <TextWrapper>
+      <TileTitle>{title}</TileTitle>
+      <div>{body}</div>
+    </TextWrapper>
+  </TileContainer>
+
+export const ContentTile = ({ title, body }) =>
+  <TileContainer $as='a' className='text-slate bg-white border-3 border-solid border-grey-2 hover:border-action'>
+    <TextWrapper>
+      <TileTitle className='text-action underline'>{title}</TileTitle>
+      <div>{body}</div>
+    </TextWrapper>
+  </TileContainer>

--- a/storybook/stories/Department Page/AboutSection.stories.jsx
+++ b/storybook/stories/Department Page/AboutSection.stories.jsx
@@ -1,0 +1,70 @@
+import React from 'react'
+import tw from 'tailwind-styled-components'
+import BigDescription from '../../src/BigDescription'
+import { InverseButton } from '../components/Buttons.stories'
+import Section from '../../src/Section'
+import SectionTitle from '../../src/SectionTitle'
+
+/** @type {import('@storybook/addons').StoryContext} */
+export default {
+  args: {
+    about: 'This is where you describe what this section is about.',
+    ctaTitle: 'Here is a call to action related to this section.',
+    ctaButton: 'Here is the call to action button',
+    publicBodies: [{ id: 45111, title: 'This is a public body' }, { id: 45211, title: 'This is another public body' }, { id: 45311, title: 'And another' }],
+    divisions: [{ id: 45112, title: 'This is a department division' }, { id: 45113, title: 'This is another division' }, { id: 45114, title: 'And another' }]
+  }
+}
+
+const CallToAction = tw.p`
+  text-title-xs
+  font-medium
+`
+
+export const AboutSection = args =>
+  <Section variant='darkblue'>
+    <SectionTitle>About</SectionTitle>
+    <AboutContent {...args} />
+  </Section>
+
+const AboutContent = ({ about, ctaTitle, ctaButton, publicBodies, divisions }) =>
+  <div className='grid grid-cols-1 lg:grid-cols-3'>
+    <BigDescription className='col-span-2 mb-24 lg:mb-60 lg:mr-60'>{about}</BigDescription>
+    <div className='col-span-1'>
+      <CallToAction>{ctaTitle}</CallToAction>
+      <InverseButton>{ctaButton}</InverseButton>
+    </div>
+    <div className='col-span-full mb-60'>
+      <InverseButton>Learn more about us</InverseButton>
+    </div>
+    <div className='col-span-2'>
+      {!!publicBodies?.length && (
+        <>
+          <div className='text-title-xs font-medium mb-24'>
+            Public bodies
+          </div>
+          <ul className='flex flex-wrap p-0 m-0 mb-40 list-none'>
+            {publicBodies.map(publicBody =>
+              <li className='mb-20 w-full lg:w-1/2 lg:pr-8' key={publicBody.id}>
+                <a className='text-white underline'>{publicBody.link.title}</a>
+              </li>
+            )}
+          </ul>
+        </>
+      )}
+      {!!divisions?.length && (
+        <>
+          <div className='text-title-xs font-medium mb-24'>
+            Divisions
+          </div>
+          <ul className='flex flex-wrap p-0 m-0 mb-40 list-none'>
+            {divisions.map(division =>
+              <li className='mb-20 w-full lg:w-1/2 lg:pr-8' key={division.id}>
+                <a className='text-white underline'>{division.link.title}</a>
+              </li>
+            )}
+          </ul>
+        </>
+      )}
+    </div>
+  </div>

--- a/storybook/stories/Department Page/DepartmentPage.stories.jsx
+++ b/storybook/stories/Department Page/DepartmentPage.stories.jsx
@@ -4,6 +4,11 @@ import { DepartmentTitleBanner } from './DepartmentTitleBanner.stories'
 import BigDescription from '../../src/BigDescription'
 import tw from 'tailwind-styled-components'
 import startCase from 'lodash.startcase'
+import Section from '../../src/Section'
+import SectionTitle from '../../src/SectionTitle'
+import { AboutSection } from './AboutSection.stories'
+import { ContactSection } from '../../src/ContactSection'
+import { ContentTile, NewsTile, TileSection } from '../../src/Tile'
 
 import CityAdministrator from './city-admininistrator.json'
 import BoardOfAppeals from './board-appeals.json'
@@ -136,63 +141,6 @@ const QuickLinkSubtitle = tw.p`
   group-hocus:text-white
 `
 
-// const QuickLinkArrowIcon = tw.sfgov-icon`
-//   flex
-//   justify-end
-//   items-end
-//   text-action
-//   group-hocus:text-white
-// `
-
-const SectionTitle = tw.h2`
-  title-xl
-  mt-0
-  mb-40
-`
-
-const NewsCard = tw.a`
-  text-slate
-  bg-yellow-3
-  hover:bg-yellow-4
-  rounded
-  p-20
-`
-
-const NewsCardTitle = tw.a`
-  block
-  text-slate
-  font-medium
-  mb-20
-`
-
-const ResourceCard = tw.a`
-bg-white
-  border-solid
-  border-3 
-  border-grey-2
-  rounded
-  p-20
-  hocus:border-action
-  text-slate
-`
-
-const ResourceCardTitle = tw.a`
-  block
-  font-medium
-  underline
-  mb-20
-`
-
-const CallToAction = tw.p`
-  text-title-xs
-  font-medium
-`
-
-const ContactSection = tw.div`
-  flex
-  items-start
-`
-
 export const DepartmentPage = ({ department }) => {
   const links = Object.keys(department).flatMap(field =>
     field === 'services' || field === 'news' || field === 'resources' || field === 'contact'
@@ -255,114 +203,42 @@ export const DepartmentPage = ({ department }) => {
       </ResponsiveContainer>
 
       {department.news?.length && (
-        <section className='bg-yellow-1 mt-60 py-80'>
-          <ResponsiveContainer>
-            <SectionTitle>News</SectionTitle>
-            <CardContainer>
-              {department.news.map(newsItem =>
-                <NewsCard key={newsItem.id}>
-                  <NewsCardTitle>{newsItem.title}</NewsCardTitle>
-                  <p>{newsItem.posted_date}</p>
-                </NewsCard>
-              )}
-            </CardContainer>
-            <Button>See more news</Button>
-          </ResponsiveContainer>
-        </section>
+        <Section variant='yellow'>
+          <SectionTitle>News</SectionTitle>
+          <TileSection>
+            {department.news.map(newsItem =>
+              <NewsTile key={newsItem.id} title={newsItem.title} body={newsItem.posted_date} />
+            )}
+          </TileSection>
+        </Section>
       )}
 
       {department.resources?.length && (
-        <section className='bg-blue-1 py-80'>
-          <ResponsiveContainer>
-            <SectionTitle>Resources</SectionTitle>
-            <CardContainer className='lg:grid-cols-2'>
-              {department.resources.map(resource =>
-                <ResourceCard key={resource.id}>
-                  <ResourceCardTitle>{resource.title}</ResourceCardTitle>
-                  <p>{resource.description}</p>
-                </ResourceCard>
-              )}
-            </CardContainer>
-          </ResponsiveContainer>
-        </section>
+        <Section variant='lightblue'>
+          <SectionTitle>Resources</SectionTitle>
+          <TileSection>
+            {department.resources.map(resource =>
+              <ContentTile key={resource.id} title={resource.title} body={resource.description} />
+            )}
+          </TileSection>
+        </Section>
       )}
 
-      <section className='bg-blue-dark text-white py-80'>
-        <ResponsiveContainer>
-          <Title>About</Title>
-          <div className='grid grid-cols-1 lg:grid-cols-3'>
-            <BigDescription className='col-span-2 mb-24 lg:mb-60 lg:mr-60'>{department.about_or_description}</BigDescription>
-            <div className='col-span-1'>
-              <CallToAction>{department.about.call_to_action.title}</CallToAction>
-              <InverseButton>{department.about.call_to_action.button.content}</InverseButton>
-            </div>
-            <div className='col-span-full mb-60'>
-              <InverseButton>Learn more about us</InverseButton>
-            </div>
-            <div className='col-span-2'>
-              {!!department.about?.public_bodies?.length && (
-                <>
-                  <div className='text-title-xs font-medium mb-24'>
-                    Public bodies
-                  </div>
-                  <ul className='flex flex-wrap p-0 m-0 mb-40 list-none'>
-                    {department.about.public_bodies.map(publicBody =>
-                      <li className='mb-20 w-full lg:w-1/2 lg:pr-8' key={publicBody.id}>
-                        <a className='text-white underline'>{publicBody.link.title}</a>
-                      </li>
-                    )}
-                  </ul>
-                </>
-              )}
-              {!!department.about?.divisions?.length && (
-                <>
-                  <div className='text-title-xs font-medium mb-24'>
-                    Divisions
-                  </div>
-                  <ul className='flex flex-wrap p-0 m-0 mb-40 list-none'>
-                    {department.about.divisions.map(division =>
-                      <li className='mb-20 w-full lg:w-1/2 lg:pr-8' key={division.id}>
-                        <a className='text-white underline'>{division.link.title}</a>
-                      </li>
-                    )}
-                  </ul>
-                </>
-              )}
-            </div>
-          </div>
-        </ResponsiveContainer>
-      </section>
+      <AboutSection
+        about={department.about_or_description}
+        ctaTitle={department.about.call_to_action.title}
+        ctaButton={department.about.call_to_action.button.content}
+        publicBodies={department.about.public_bodies}
+        divisions={department.about.divisions}
+      />
 
-      <ResponsiveContainer className='my-80'>
-        <SectionTitle>Contact</SectionTitle>
-        <CardContainer>
-          <ContactSection>
-            <sfgov-icon symbol='location' class='pr-20' />
-            <div>
-              <h3 className='mt-0'>{department.title}</h3>
-              <div>{department.contact.address[0].address.address_line1}</div>
-              <div>{department.contact.address[0].address.address_line2}</div>
-              <div>{`${department.contact.address[0].address.locality}, ${department.contact.address[0].address.administrative_area} ${department.contact.address[0].address.postal_code}`}</div>
-              <div className='bg-grey-2 h-100 w-100 mt-40 mb-20 p-20 rounded text-center'>A map will go here</div>
-              <a href='https://www.google.com/maps/dir/?api=1&amp;destination=1+Dr.+Carlton+B.+Goodlett+Place%2CCity+Hall+Room+362%2C+San+Francisco%2CCA+94102' target='_blank' rel='noreferrer'>Get directions</a>
-            </div>
-          </ContactSection>
-          <ContactSection>
-            <sfgov-icon symbol='phone' class='pr-20'/>
-            <div>
-              <h3 className='mt-0'>Phone</h3>
-              <div>{department.contact.phone_numbers[0].owner}</div>
-              <a href={`tel:${department.contact.phone_numbers[0].tel}`}>{department.contact.phone_numbers[0].tel}</a>
-            </div>
-          </ContactSection>
-          <ContactSection>
-            <sfgov-icon symbol='mail' class='pr-20'/>
-            <div>
-              <h3 className='mt-0'>Email</h3>
-              <a href={`mailto:${department.contact.email[0].email}`}>{department.contact.email[0].email}</a>
-            </div>
-          </ContactSection>
-        </CardContainer>
+      <ContactSection
+        address={department.contact.address[0].address}
+        phone={department.contact.phone_numbers}
+        email={department.contact.email[0]}
+      />
+
+      <ResponsiveContainer>
         <div className='p-40 lg:flex lg:space-x-20 rounded bg-blue-1'>
           <div>
             <h3>Request public record</h3>

--- a/storybook/stories/Department Page/board-appeals.json
+++ b/storybook/stories/Department Page/board-appeals.json
@@ -67,6 +67,7 @@
         "content_translation_outdated": false,
         "content_translation_changed": "2021-06-24T17:44:23+00:00",
         "address": {
+          "title": "Board of Appeals",
           "langcode": "",
           "country_code": "US",
           "administrative_area": "CA",

--- a/storybook/stories/Department Page/city-admininistrator.json
+++ b/storybook/stories/Department Page/city-admininistrator.json
@@ -135,6 +135,7 @@
         "content_translation_outdated": false,
         "content_translation_changed": "2021-06-24T17:44:23+00:00",
         "address": {
+          "title": "City Administrator",
           "langcode": "",
           "country_code": "US",
           "administrative_area": "CA",

--- a/storybook/stories/components/PageSection.stories.jsx
+++ b/storybook/stories/components/PageSection.stories.jsx
@@ -1,0 +1,35 @@
+import React from 'react'
+import Section from '../../src/Section'
+import SectionTitle from '../../src/SectionTitle'
+import { ContentTile, NewsTile, TileSection } from '../../src/Tile'
+
+const imgSrc = 'https://sf.gov/sites/default/files/styles/default/public/2021-10/san-francisco-street-day-time.jpg?itok=5QqBW-AZ'
+
+/** @type {import('@storybook/addons').StoryContext} */
+export default {
+  title: 'Page Section'
+}
+
+export const NewsSection = args =>
+  <Section variant='yellow'>
+    {args.title && <SectionTitle>{args.title}</SectionTitle>}
+    <TileSection>
+      {[...Array(3)].map((_, i) =>
+        <NewsTile key={i} title='Some news is occurring' body='Here is some info about the news' img={imgSrc} />
+      )}
+    </TileSection>
+  </Section>
+
+NewsSection.args = { title: 'News' }
+
+export const ServicesSection = args =>
+  <Section variant='lightblue'>
+    {args.title && <SectionTitle>{args.title}</SectionTitle>}
+    <TileSection>
+      {[...Array(3)].map((_, i) =>
+        <ContentTile key={i} title='Here is a service' body='Here is some info about the service' />
+      )}
+    </TileSection>
+  </Section>
+
+ServicesSection.args = { title: 'Services' }

--- a/storybook/stories/components/PageSection.stories.jsx
+++ b/storybook/stories/components/PageSection.stories.jsx
@@ -2,6 +2,7 @@ import React from 'react'
 import Section from '../../src/Section'
 import SectionTitle from '../../src/SectionTitle'
 import { ContentTile, NewsTile, TileSection } from '../../src/Tile'
+import { ContactSection as ContactSectionComponent } from '../../src/ContactSection'
 
 const imgSrc = 'https://sf.gov/sites/default/files/styles/default/public/2021-10/san-francisco-street-day-time.jpg?itok=5QqBW-AZ'
 
@@ -33,3 +34,24 @@ export const ServicesSection = args =>
   </Section>
 
 ServicesSection.args = { title: 'Services' }
+
+export const ContactSection = args => <ContactSectionComponent {...args} />
+
+ContactSection.args = {
+  address: {
+    title: 'City Administrator',
+    line1: '1 Dr. Carlton B. Goodlett Place',
+    line2: 'City Hall Room 362',
+    locality: 'San Francisco',
+    administrative_area: 'CA',
+    postal_code: '94102'
+  },
+  phone: [{
+    owner: '',
+    tel: '415-554-4851'
+  }],
+  email: {
+    owner: '',
+    email: 'city.administrator@sfgov.org'
+  }
+}

--- a/storybook/stories/components/Tiles.stories.jsx
+++ b/storybook/stories/components/Tiles.stories.jsx
@@ -1,7 +1,15 @@
-import { Stub } from '../../src/utils'
+import React from 'react'
+import {
+  ContentTile as ContentTileComponent,
+  FeatureTile as FeatureTileComponent,
+  NewsTile as NewsTileComponent
+} from '../../src/Tile'
+
+const imgSrc = 'https://sf.gov/sites/default/files/styles/default/public/2021-10/san-francisco-street-day-time.jpg?itok=5QqBW-AZ'
 
 /** @type {import('@storybook/addons').StoryContext} */
 export default {
+  decorators: [(Story) => <div className='max-w-md'><Story /></div>],
   parameters: {
     design: {
       type: 'figma',
@@ -11,19 +19,31 @@ export default {
 }
 
 /** @type {import('@storybook/react').Story} */
-export const EventTile = Stub.bind({})
+export const NewsTile = NewsTileComponent.bind({})
+NewsTile.args = {
+  title: 'news!',
+  body: 'Monday, April 28',
+  img: imgSrc
+}
 
 /** @type {import('@storybook/react').Story} */
-export const NewsTile = Stub.bind({})
+export const FeatureTile = FeatureTileComponent.bind({})
+FeatureTile.args = {
+  title: 'feature tile',
+  body: 'This is a feature tile body'
+}
 
 /** @type {import('@storybook/react').Story} */
-export const FeatureTile = Stub.bind({})
+export const ContentTile = ContentTileComponent.bind({})
+ContentTile.args = {
+  title: 'content tile',
+  body: 'This is a content tile body'
+}
 
-/** @type {import('@storybook/react').Story} */
-export const ContentTile = Stub.bind({})
+// /** @type {import('@storybook/react').Story} */
+// export const QuickLink = TileTemplate.bind({})
+// QuickLink.args = { ...EventTile.args, body: 'This is a feature tile body', variant: 'Feature' }
 
-/** @type {import('@storybook/react').Story} */
-export const QuickLink = Stub.bind({})
-
-/** @type {import('@storybook/react').Story} */
-export const TopicTile = Stub.bind({})
+// /** @type {import('@storybook/react').Story} */
+// export const TopicTile = TileTemplate.bind({})
+// TopicTile.args = { ...EventTile.args, body: 'This is a feature tile body', variant: 'Feature' }


### PR DESCRIPTION
Adds:
- News, Feature, and Content tiles
- Section and section title components
- Two stories:
   - One for tiles
   - Another for Page Sections (News and Services sections)

TBD:
- Where do we use Event Tiles? I wasn't able to find any use of them on sf.gov
- Should we rename the SectionTitle to something more generic?