### PR TITLE
BREAKING: new font stack

### DIFF
--- a/packages/react/src/components/GlobalStyle.tsx
+++ b/packages/react/src/components/GlobalStyle.tsx
@@ -1,41 +1,26 @@
 import React, { ComponentProps } from 'react'
-
-export type GoogleFontsSpec = Record<string, string>
+import { getGoogleFontsCss } from './GoogleFonts'
+import type { FontSpec } from '../types'
 
 export type GlobalCSSProps = {
-  googleFonts?: GoogleFontsSpec
+  fonts?: FontSpec[]
 }
 
 export type GlobalStyleProps = Omit<ComponentProps<'style'>, 'dangerouslySetInnerHTML'> & GlobalCSSProps
 
-export const DEFAULT_GOOGLE_FONTS: GoogleFontsSpec = {
-  Rubik: 'wght@300;400;600',
-  'Noto Sans TC': 'wght@300;400;500',
-  'Roboto Mono': 'wght@400'
-}
-
-export function getDefaultGlobalCss ({ googleFonts = DEFAULT_GOOGLE_FONTS }: GlobalCSSProps) {
-  return `
-    @import url('${getGoogleFontsURL(googleFonts)}');
-  `.trim()
-}
-
-export function GlobalStyle ({ googleFonts = DEFAULT_GOOGLE_FONTS, ...rest }: GlobalStyleProps) {
-  return <style id='sfgov-global-css' dangerouslySetInnerHTML={{
-    __html: getDefaultGlobalCss({ googleFonts })
+/**
+ * @param props 
+ * @returns a global <style> "singleton"
+ */
+export function GlobalStyle ({ fonts, ...rest }: GlobalStyleProps) {
+  return <style id='sfgov-global-css' {...rest} dangerouslySetInnerHTML={{
+    __html: getDefaultGlobalCss({ fonts })
   }} />
 }
 
-export function getGoogleFontsURL (fonts: GoogleFontsSpec = DEFAULT_GOOGLE_FONTS) {
-  if (!fonts || typeof fonts !== 'object' || Array.isArray(fonts)) {
-    throw new Error(`Expected a Google Fonts object spec, but got ${typeof fonts}`)
-  }
-  const families = Object.entries(fonts)
-    .map(([family, args]) => `family=${escape(family)}${args ? `:${args}` : ''}`)
-    .join('&')
-  return `https://fonts.googleapis.com/css2?${families}&display=swap`
-}
-
-function escape (str: string) {
-  return str.replace(/ /g, '+')
+export function getDefaultGlobalCss (props?: GlobalCSSProps): string {
+  return [
+    '* { box-sizing: border-box; }',
+    getGoogleFontsCss(props?.fonts)
+  ].join('')
 }

--- a/packages/react/src/components/GlobalStyle.tsx
+++ b/packages/react/src/components/GlobalStyle.tsx
@@ -1,26 +1,35 @@
 import React, { ComponentProps } from 'react'
 import { getGoogleFontsCss } from './GoogleFonts'
-import type { FontSpec } from '../types'
-
-export type GlobalCSSProps = {
-  fonts?: FontSpec[]
-}
+import type { GlobalCSSProps } from '../types'
+import { SSRStyle } from './SSRStyle'
 
 export type GlobalStyleProps = Omit<ComponentProps<'style'>, 'dangerouslySetInnerHTML'> & GlobalCSSProps
 
 /**
+ * This component renders a <style> tag that pulls in static
+ * global CSS, including Google Fonts CSS imports. For critical CSS rendered
+ * server-side, use <SSRStyle>.
+ * 
+ * @see {SSRStyle}
+ * @see {getGlobalStaticCss}
  * @param props 
  * @returns a global <style> "singleton"
  */
-export function GlobalStyle ({ fonts, ...rest }: GlobalStyleProps) {
+export function GlobalStaticStyles ({ fonts, ...rest }: GlobalStyleProps) {
   return <style id='sfgov-global-css' {...rest} dangerouslySetInnerHTML={{
-    __html: getDefaultGlobalCss({ fonts })
+    __html: getStaticGlobalCss({ fonts })
   }} />
 }
 
-export function getDefaultGlobalCss (props?: GlobalCSSProps): string {
+/**
+ * For static and non-React environments, use this function to generate CSS
+ * content for a global <style> element.
+ * 
+ * @param props 
+ * @returns 
+ */
+export function getStaticGlobalCss (props?: GlobalCSSProps): string {
   return [
-    '* { box-sizing: border-box; }',
     getGoogleFontsCss(props?.fonts)
   ].join('')
 }

--- a/packages/react/src/components/GoogleFonts.tsx
+++ b/packages/react/src/components/GoogleFonts.tsx
@@ -1,0 +1,42 @@
+import type { FontSpec, LinkProps } from '../types'
+import { defaultFonts } from '../constants'
+
+export function getGoogleFontsCss (fonts?: FontSpec[]) {
+  return `@import url('${getGoogleFontsURL(fonts)}');`
+}
+
+export function getGoogleFontsURL (fonts?: FontSpec[]) {
+  const families = (fonts || defaultFonts)
+    .map(font => [
+      font.name,
+      formatFontWeights(font)
+    ])
+    .map(([family, args]) => `family=${escape(family)}${args ? `:${args}` : ''}`)
+    .join('&')
+  return `https://fonts.googleapis.com/css2?${families}&display=swap`
+}
+
+export function getPreloadLinks (fonts?: FontSpec[]): LinkProps[] {
+  const url = getGoogleFontsURL(fonts || defaultFonts)
+  if (!url) return []
+  return [
+    { rel: 'preconnect', href: 'https://fonts.gstatic.com', crossOrigin: 'anonymous' },
+    { rel: 'preload', as: 'style', href: url },
+    { rel: 'stylesheet', href: url }
+  ]
+}
+
+function formatFontWeights (font: FontSpec) {
+  if (font.googleFont?.optical) {
+    const weights = Object.values(font.googleFont.weights)
+      .map(([range, weight]) => `${range.join('..')},${weight}`)
+    return `opsz,wght@${weights.join(';')}`
+  } else {
+    const { weights } = font
+    return `wght@${Object.values(weights).join(';')}`
+  }
+}
+
+function escape (str: string) {
+  return str.replace(/ /g, '+')
+}

--- a/packages/react/src/components/GoogleFonts.tsx
+++ b/packages/react/src/components/GoogleFonts.tsx
@@ -1,5 +1,40 @@
-import type { FontSpec, LinkProps } from '../types'
+import React, { ComponentProps } from 'react'
 import { defaultFonts } from '../constants'
+import type { FontSpec, FontSpecProps, LinkProps } from '../types'
+
+/**
+ * Render a <style> tag that imports the necessary Google Fonts for our typography.
+ * This can be used for client-side rendering, but will cause a flash of unstyled
+ * typography. If you have the ability to render server-side, please use
+ * {@link GoogleFontsPreloadStyles} or {@link SSRStyle} instead.
+ * 
+ * @param props <style> props and FontSpecProps (including the `fonts` prop), plus
+ * additional CSS text as children (strings)
+ */
+export function GoogleFontsStylesheet ({ fonts, children, ...rest }: ComponentProps<'style'> & FontSpecProps) {
+  const url = getGoogleFontsURL(fonts)
+  return url
+    ? <style {...rest}>{`@import url(${url});`}{children}</style>
+    : null
+}
+
+export function GoogleFontsPreloadStyles (props: FontSpecProps) {
+  return <>
+    {getGooglePreloadLinks(props.fonts).map((props, i) => (
+      <link key={i} {...props} />
+    ))}
+  </>
+}
+
+export function getGooglePreloadLinks (fonts?: FontSpec[]): LinkProps[] {
+  const url = getGoogleFontsURL(fonts || defaultFonts)
+  if (!url) return []
+  return [
+    { rel: 'preconnect', href: 'https://fonts.gstatic.com', crossOrigin: 'anonymous' },
+    { rel: 'preload', as: 'style', href: url },
+    { rel: 'stylesheet', href: url }
+  ]
+}
 
 export function getGoogleFontsCss (fonts?: FontSpec[]) {
   return `@import url('${getGoogleFontsURL(fonts)}');`
@@ -14,16 +49,6 @@ export function getGoogleFontsURL (fonts?: FontSpec[]) {
     .map(([family, args]) => `family=${escape(family)}${args ? `:${args}` : ''}`)
     .join('&')
   return `https://fonts.googleapis.com/css2?${families}&display=swap`
-}
-
-export function getPreloadLinks (fonts?: FontSpec[]): LinkProps[] {
-  const url = getGoogleFontsURL(fonts || defaultFonts)
-  if (!url) return []
-  return [
-    { rel: 'preconnect', href: 'https://fonts.gstatic.com', crossOrigin: 'anonymous' },
-    { rel: 'preload', as: 'style', href: url },
-    { rel: 'stylesheet', href: url }
-  ]
 }
 
 function formatFontWeights (font: FontSpec) {

--- a/packages/react/src/components/SSRStyle.tsx
+++ b/packages/react/src/components/SSRStyle.tsx
@@ -1,8 +1,7 @@
 import React, { ComponentProps } from 'react'
-import type { GlobalCSSProps } from './GlobalStyle'
-import { getPreloadLinks as getGooglePreloadLinks } from './GoogleFonts'
+import { getGooglePreloadLinks, GoogleFontsPreloadStyles } from './GoogleFonts'
 import { getCssText, reset } from '../stitches.config'
-import { FontSpec } from '../types'
+import type { GlobalCSSProps } from '../types'
 
 export type SSRStyleProps = Omit<ComponentProps<'style'>, 'dangerouslySetInnerHTML'> & GlobalCSSProps
 
@@ -26,9 +25,8 @@ export type SSRStyleProps = Omit<ComponentProps<'style'>, 'dangerouslySetInnerHT
 export function SSRStyle ({ fonts, ...rest }: SSRStyleProps) {
   const css = getCssText()
   reset()
-  const links = getPreloadLinks({ fonts })
   return <>
-    {links.map((props, i) => <link key={i} {...props} />)}
+    <GoogleFontsPreloadStyles fonts={fonts} />
     <style id='sfgov-ssr-css' {...rest} dangerouslySetInnerHTML={{ __html: css }} />
   </>
 }

--- a/packages/react/src/components/SSRStyle.tsx
+++ b/packages/react/src/components/SSRStyle.tsx
@@ -1,6 +1,8 @@
 import React, { ComponentProps } from 'react'
-import { GlobalCSSProps, getGoogleFontsURL, DEFAULT_GOOGLE_FONTS } from './GlobalStyle'
+import type { GlobalCSSProps } from './GlobalStyle'
+import { getPreloadLinks as getGooglePreloadLinks } from './GoogleFonts'
 import { getCssText, reset } from '../stitches.config'
+import { FontSpec } from '../types'
 
 export type SSRStyleProps = Omit<ComponentProps<'style'>, 'dangerouslySetInnerHTML'> & GlobalCSSProps
 
@@ -21,14 +23,20 @@ export type SSRStyleProps = Omit<ComponentProps<'style'>, 'dangerouslySetInnerHT
  * @param props
  * @returns a fragment suitable for use in <head>, Helmet, next/head, etc.
  */
-export function SSRStyle ({ googleFonts, ...rest }: SSRStyleProps) {
+export function SSRStyle ({ fonts, ...rest }: SSRStyleProps) {
   const css = getCssText()
   reset()
-  const links = SSRStyle.getPreloadLinks({ googleFonts })
+  const links = getPreloadLinks({ fonts })
   return <>
     {links.map((props, i) => <link key={i} {...props} />)}
     <style id='sfgov-ssr-css' {...rest} dangerouslySetInnerHTML={{ __html: css }} />
   </>
+}
+
+function getPreloadLinks (props?: SSRStyleProps) {
+  return [
+    ...getGooglePreloadLinks(props?.fonts)
+  ]
 }
 
 /**
@@ -40,11 +48,4 @@ export function SSRStyle ({ googleFonts, ...rest }: SSRStyleProps) {
  *   listing the fonts to be loaded.
  * @returns an array of <link> attribute/props objects
  */
-SSRStyle.getPreloadLinks = (props?: SSRStyleProps) => {
-  const googleFontsUrl = getGoogleFontsURL(props?.googleFonts || DEFAULT_GOOGLE_FONTS)
-  return [
-    { rel: 'preconnect', href: 'https://fonts.gstatic.com', crossOrigin: 'anonymous' },
-    { rel: 'preload', as: 'style', href: googleFontsUrl },
-    { rel: 'stylesheet', href: googleFontsUrl }
-  ] as ComponentProps<'link'>[]
-}
+SSRStyle.getPreloadLinks = getPreloadLinks

--- a/packages/react/src/constants.ts
+++ b/packages/react/src/constants.ts
@@ -1,1 +1,48 @@
+import type { FontSpec } from './types'
+
 export const HOCUS_SELECTOR = '&:hover, &:focus'
+
+export const defaultFonts: FontSpec[] = [
+  {
+    name: 'Noto Sans TC',
+    fallbacks: ['ui-sans-serif', 'sans-serif'],
+    weights: {
+      light: 300,
+      normal: 400,
+      bold: 500
+    }
+  },
+  {
+    name: 'Roboto Flex',
+    fallbacks: ['ui-sans-serif', 'sans-serif'],
+    weights: {
+      light: 300,
+      normal: 400,
+      bold: 700
+    },
+    googleFont: {
+      optical: true,
+      weights: {
+        light: [[8, 144], 300],
+        normal: [[8, 144], 400],
+        bold: [[8, 144], 700]
+      }
+    }
+  },
+  {
+    name: 'Roboto Slab',
+    fallbacks: ['ui-serif', 'serif'],
+    weights: {
+      light: 300,
+      normal: 400,
+      bold: 700
+    }
+  },
+  {
+    name: 'Roboto Mono',
+    fallbacks: ['ui-monospace', 'monospace'],
+    weights: {
+      normal: 400
+    }
+  }
+]

--- a/packages/react/src/theme/typography.ts
+++ b/packages/react/src/theme/typography.ts
@@ -1,12 +1,18 @@
 import { CSS } from '@stitches/react'
+import { defaultFonts } from '../constants'
 
 export const fonts = {
-  rubik: 'Rubik, ui-sans-serif, sans-serif',
-  roboto: 'Roboto mono, ui-monospace, monospace',
-  noto: 'Noto Sans TC, ui-sans-serif, sans-serif',
-  body: '$rubik',
-  chinese: '$noto',
-  monospace: '$roboto'
+  body: '$sans',
+  sans: '$RobotoFlex',
+  slab: '$RobotoSlab',
+  monospace: '$RobotoMono',
+  chinese: '$NotoSansTC',
+  ...Object.fromEntries(
+    defaultFonts.map(font => [
+      font.name.replace(/ +/g, ''),
+      `${[font.name, ...font.fallbacks
+    ].join(', ')}`])
+  )
 }
 
 export const textStyles: Record<string, CSS> = {
@@ -34,91 +40,83 @@ export const textStyles: Record<string, CSS> = {
     lineHeight: '32px'
   },
   titleXs: {
-    fontFamily: '$body',
+    fontFamily: '$sans',
     fontSize: '20px',
     fontWeight: '$bold',
     lineHeight: '24px'
   },
   titleSm: {
-    fontFamily: '$body',
+    fontFamily: '$sans',
     fontSize: '24px',
     fontWeight: '$bold',
     lineHeight: '28px'
   },
   titleMd: {
-    fontFamily: '$body',
+    fontFamily: '$slab',
     fontSize: '24px',
     fontWeight: '$bold',
     lineHeight: '28px'
   },
   titleLg: {
-    fontFamily: '$body',
+    fontFamily: '$slab',
     fontSize: '28px',
     fontWeight: '$bold',
-    lineHeight: '32px',
-    letterSpacing: '-1px'
+    lineHeight: '32px'
   },
   titleXl: {
-    fontFamily: '$body',
+    fontFamily: '$slab',
     fontSize: '32px',
     fontWeight: '$bold',
-    lineHeight: '36px',
-    letterSpacing: '-1px'
+    lineHeight: '36px'
   },
   displaySm: {
-    fontFamily: '$body',
+    fontFamily: '$slab',
     fontSize: '36px',
     fontWeight: '$light',
-    lineHeight: '40px',
-    letterSpacing: '-1px'
+    lineHeight: '40px'
   },
   displayLg: {
-    fontFamily: '$body',
+    fontFamily: '$slab',
     fontSize: '44px',
     fontWeight: '$light',
-    lineHeight: '48px',
-    letterSpacing: '-1px'
+    lineHeight: '48px'
   },
   titleMdDesktop: {
-    fontFamily: '$body',
+    fontFamily: '$slab',
     fontSize: '32px',
     fontWeight: '$bold',
     lineHeight: '36px'
   },
   titleLgDesktop: {
-    fontFamily: '$body',
+    fontFamily: '$slab',
     fontSize: '44px',
     fontWeight: '$bold',
-    lineHeight: '52px',
-    letterSpacing: '-1px'
+    lineHeight: '52px'
   },
   titleXlDesktop: {
-    fontFamily: '$body',
+    fontFamily: '$slab',
     fontSize: '60px',
     fontWeight: '$bold',
-    lineHeight: '64px',
-    letterSpacing: '-1px'
+    lineHeight: '64px'
   },
   displaySmDesktop: {
-    fontFamily: '$body',
+    fontFamily: '$slab',
     fontSize: '48px',
     fontWeight: '$light',
-    lineHeight: '52px',
-    letterSpacing: '-1px'
+    lineHeight: '52px'
   },
   displayLgDesktop: {
-    fontFamily: '$body',
+    fontFamily: '$slab',
     fontSize: '72px',
     fontWeight: '$light',
-    lineHeight: '76px',
-    letterSpacing: '-2px'
+    lineHeight: '76px'
   }
 }
 
 export const fontWeights = {
   light: 300,
   normal: 400,
-  bold: 600,
+  bold: 700,
   boldChinese: 500,
   ...collect('fontWeight')
 }

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -1,0 +1,25 @@
+import type { ComponentProps } from 'react'
+
+export type LinkProps = ComponentProps<'link'>
+
+export type FontWeightName = 'light' | 'normal' | 'bold' | 'semibold'
+export type FixedFontWeightMap = Partial<Record<FontWeightName, number>>
+
+// "8..144,300;8..144,400;8..144,700"
+type OpticalWeights = Partial<Record<FontWeightName, [number[], number]>>
+
+export type OpticalGoogleFont = {
+  optical: true
+  weights: OpticalWeights
+}
+
+export type GoogleFontOptions = {
+  optical: false
+} | OpticalGoogleFont
+
+export type FontSpec = {
+  name: string
+  fallbacks?: string[]
+  weights: FixedFontWeightMap
+  googleFont?: GoogleFontOptions
+}

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -23,3 +23,9 @@ export type FontSpec = {
   weights: FixedFontWeightMap
   googleFont?: GoogleFontOptions
 }
+
+export type FontSpecProps = {
+  fonts?: FontSpec[]
+}
+
+export type GlobalCSSProps = FontSpecProps

--- a/storybook/.storybook/main.js
+++ b/storybook/.storybook/main.js
@@ -86,8 +86,8 @@ module.exports = {
 function tag (name, attrs) {
   const attrString = attrs
     ? Object.entries(attrs)
-        .map(([name, value]) => ` ${name}="${escapeAttrValue(value)}"`)
-        .join('')
+      .map(([name, value]) => ` ${name}="${escapeAttrValue(value)}"`)
+      .join('')
     : ''
   return `<${name}${attrString}>`
 }

--- a/website/package.json
+++ b/website/package.json
@@ -44,6 +44,7 @@
       "command": "docusaurus start --port=3002",
       "dependencies": [
         "link-storybook",
+        "../packages/react:build",
         "../packages/sfgov-design-system:build"
       ]
     },

--- a/website/src/plugins/sfgov/index.js
+++ b/website/src/plugins/sfgov/index.js
@@ -3,8 +3,8 @@ const { SSRStyle } = require('@sfgov/react')
 /** @type {import('@docusaurus/types').PluginModule} */
 module.exports = context => ({
   injectHtmlTags ({ content }) {
+    // FIXME: do something with `content` here?
     const links = SSRStyle.getPreloadLinks()
-    console.log('content:', content)
     return {
       name: 'sfgov-design-system',
       headTags: [


### PR DESCRIPTION
I'm consolidating the changes for the new font stack in this PR as best I can, but I admit that the diff is hard to read because I had to refactor some bits to make the `defaultFonts` list work as a source of data for both the typography styles and the Google Fonts imports. I'm going to merget this into #144 and then mark that as ready for review.