### PR TITLE
Run build:ci script in actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,9 +20,7 @@ jobs:
       # this sets NODE_ENV=production for all of the build scripts
       - run: echo NODE_ENV=production >> $GITHUB_ENV
 
-      - run: npm run build -w sfgov-design-system
-      - run: npm run build -w @sfgov/icons
-      - run: npm run build -w @sfgov/react
+      - run: npm run build:ci
 
       - name: Git identity
         run: |

--- a/.github/workflows/reports.yml
+++ b/.github/workflows/reports.yml
@@ -10,4 +10,4 @@ jobs:
         with:
           repo-token: ${{ github.token }}
           pattern: 'packages/*/dist/**/*.{js,mjs,css,svg}'
-          build-script: build -w sfgov-design-system -w @sfgov/react
+          build-script: 'build:ci'

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "scripts": {
     "build": "lerna run build",
+    "build:ci": "npm run -w sfgov-design-system -w @sfgov/react",
     "lint": "lerna run lint",
     "postbuild": "cp -rf storybook/public/ website/public/storybook/",
     "start": "wireit",


### PR DESCRIPTION
As mentioned in [this comment](https://github.com/SFDigitalServices/design-system/pull/153#issuecomment-1402295951), we need to tweak how reports are generated on the `main` branch before we can see the size comparison in #153.

Note: the reports build for this PR fails because of the way that the compressed size action works. It runs the same build script on both the head ref (`fix/build-ci-script`) and `main`, but the `main` branch isn't set up properly to run `build` on Actions (it wants to run `build -w @sfgov/react -w sfgov-design-system` instead), and fails. Merging this PR _should_ fix the reports build on both this PR and #153. 🤞 