### PR TITLE
Remove dist dirs in built output

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,10 +2,15 @@
 module.exports = {
   parser: '@babel/eslint-parser',
   ignorePatterns: [
-    'dist',
-    '*/public',
-    '**/.wireit',
+    // built files
+    'elements/index.*',
+    'react/index.*',
+    'public/**',
+    // caches, etc.
+    '.wireit/**',
+    // do _not_ ignore root JS configs
     '!.*.{js,mjs}',
+    // do _not_ ignore Storybook configs
     '!.storybook'
   ],
   plugins: [
@@ -55,7 +60,7 @@ module.exports = {
   reportUnusedDisableDirectives: true,
   overrides: [
     {
-      files: ['**/*.browser.{js,jsx,mjs,ts,tsx'],
+      files: ['elements/src/**/*.js'],
       env: {
         browser: true
       }

--- a/.github/workflows/reports.yml
+++ b/.github/workflows/reports.yml
@@ -9,5 +9,6 @@ jobs:
       - uses: preactjs/compressed-size-action@v2
         with:
           repo-token: ${{ github.token }}
-          pattern: 'dist/**/*.{css,js,mjs,svg}'
+          pattern: '{css,elements,icons,react}/**/*.{css,js,mjs,svg}'
+          exclude: '*/src/**'
           build-script: 'build:ci'

--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,19 @@
+# etc.
 **/.DS_Store
-**/.env
-**/.eslintcache
 **/*.log
-**/.wireit
-**/build
-**/dist
+
+# secrets
+/.env
+
+# caches
+**/.eslintcache
+/.wireit/
+/node_modules/
+
+# built files
+/css/*.css*
+/css/*.json
+/elements/index.*
+/react/index.*
+/public/
 **/manifest.json
-node_modules/
-public/

--- a/.storybook/preview.jsx
+++ b/.storybook/preview.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { INITIAL_VIEWPORTS } from '@storybook/addon-viewport'
 import { addParameters, addDecorator } from '@storybook/react'
+// eslint-disable-next-line import/no-unresolved
 import { Box, breakpoints } from '../react'
 import { getDocsBaseUrl } from '../stories/utils'
 

--- a/elements/.eslintrc.js
+++ b/elements/.eslintrc.js
@@ -1,6 +1,0 @@
-/** @type {import('eslint').Linter.Config} */
-module.exports = {
-  env: {
-    browser: true
-  }
-}

--- a/elements/index.js
+++ b/elements/index.js
@@ -1,1 +1,0 @@
-module.exports = require('../dist/elements/index.js')

--- a/elements/index.mjs
+++ b/elements/index.mjs
@@ -1,1 +1,0 @@
-export * from '../dist/elements/index.mjs'

--- a/package.json
+++ b/package.json
@@ -77,23 +77,23 @@
       ]
     },
     "build:css": {
-      "command": "postcss --verbose -d dist/css 'css/src/*.css'",
+      "command": "postcss --verbose -d css 'css/src/*.css'",
       "files": [
-        "css/**",
-        "postcss.config.js"
+        "css/src/**",
+        "postcss.config.js",
+        "package.json"
       ],
       "output": [
-        "dist/**/*.css{,.map}"
+        "css/*.css{,.map,.json}"
       ]
     },
     "build:css-manifest": {
       "command": "node scripts/build-css-manifest.js",
       "output": [
-        "dist/css/utilties.json"
+        "css/utilties.json"
       ],
       "files": [
-        "dist/css",
-        "!dist/css/**/*.json"
+        "css/*.css"
       ],
       "dependencies": [
         "build:css"
@@ -118,11 +118,12 @@
     "build:js": {
       "command": "rollup -c",
       "files": [
-        "{elements,icons,react}/src/**",
-        "*.config.*"
+        "{elements,react}/src/**",
+        "*.config.*",
+        "package.json"
       ],
       "output": [
-        "dist/**/*.{js,mjs}{,.map}"
+        "{elements,react}/*.{js,mjs,ts}{,.map}"
       ]
     },
     "build:website-index": {
@@ -140,14 +141,14 @@
       ]
     },
     "build:manifest": {
-      "command": "scripts/manifest.mjs 'dist/**/*.{css,js,mjs,svg}'",
+      "command": "scripts/manifest.mjs 'css/*.css' '{elements,react}/*.{js,mjs}' 'icons/svg/*.svg'",
       "dependencies": [
         "build:css",
         "build:js",
         "build:css-manifest"
       ],
       "output": [
-        "dist/manifest.json"
+        "manifest.json"
       ]
     },
     "build:storybook": {

--- a/react/index.js
+++ b/react/index.js
@@ -1,1 +1,0 @@
-module.exports = require('../dist/react/index.js')

--- a/react/index.mjs
+++ b/react/index.mjs
@@ -1,1 +1,0 @@
-export * from '../dist/react/index.mjs'

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -37,12 +37,12 @@ export default [
     plugins: commonPlugins,
     output: [
       {
-        file: 'dist/elements/index.mjs',
+        file: 'elements/index.mjs',
         format: 'esm',
         sourcemap
       },
       {
-        file: 'dist/elements/index.js',
+        file: 'elements/index.js',
         format: 'umd',
         name: 'sfgov.elements',
         sourcemap
@@ -54,12 +54,12 @@ export default [
     plugins: commonPlugins,
     output: [
       {
-        file: 'dist/react/index.mjs',
+        file: 'react/index.mjs',
         format: 'esm',
         sourcemap
       },
       {
-        file: 'dist/react/index.js',
+        file: 'react/index.js',
         format: 'umd',
         name: 'sfgov.react',
         sourcemap,

--- a/scripts/build-css-manifest.js
+++ b/scripts/build-css-manifest.js
@@ -66,10 +66,10 @@ const tailwindCategories = [
 ]
 
 const utilities = [
-  getUtilities('dist/css/utilities.css').byProperty
+  getUtilities('css/utilities.css').byProperty
 ]
 const manifest = buildManifest(utilities)
-writeFileSync('dist/css/utilities.json', JSON.stringify(manifest, null, 2), 'utf8')
+writeFileSync('css/utilities.json', JSON.stringify(manifest, null, 2), 'utf8')
 
 function buildManifest (utilities) {
   const manifest = tailwindCategories

--- a/scripts/check-prepublish-files.sh
+++ b/scripts/check-prepublish-files.sh
@@ -18,11 +18,11 @@ function assert_exists () {
 
 echo "Checking for expected files..."
 assert_exists \
-  dist/css/{sfds,base,components,typography,utilities}.css \
-  elements/index.{js,mjs} dist/elements/index.{js,mjs} \
+  css/{sfds,base,components,typography,utilities}.css \
+  elements/index.{js,mjs,d.ts} \
   icons/index.json icons/svg/{accessibility,plus,minus}.svg \
-  react/index.{js,mjs} dist/react/index.{js,mjs} \
-  dist/manifest.json \
+  react/index.{js,mjs,d.ts} \
+  manifest.json \
 || exit 1
 
 echo "🚀 Good to go!"

--- a/scripts/manifest.mjs
+++ b/scripts/manifest.mjs
@@ -33,6 +33,6 @@ globby([...globs, '!**/manifest.json'])
 
     // eslint-disable-next-line promise/no-nesting, promise/always-return
     return ensureDir('dist').then(() => {
-      writeFileSync('dist/manifest.json', JSON.stringify(manifest, null, 2), 'utf8')
+      writeFileSync('manifest.json', JSON.stringify(manifest, null, 2), 'utf8')
     })
   })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,10 @@
 {
   "files": [
-    "./elements/src/index.js",
-    "./react/src/index.ts"
+    "react/src/index.ts"
   ],
   "exclude": [
-    "**/dist/**",
+    "elements/index.{js,mjs}",
+    "react/index.{js,mjs}",
     "**/node_modules/**",
     "**/*.config.*",
     "**/scripts/*.js"

--- a/website/docs/develop/css/index.mdx
+++ b/website/docs/develop/css/index.mdx
@@ -14,7 +14,7 @@ bundles:
     desc: Includes all of the [Tailwind]-generated utility classes.
 ---
 
-import manifest from '@sfgov/design-system/dist/manifest.json'
+import manifest from '@sfgov/design-system/manifest.json'
 import CodeBlock from '@theme/CodeBlock'
 import { defaultPackage } from '@site/constants'
 import { publishedUrl } from '@site/src/utils'
@@ -32,14 +32,14 @@ site without the need for a custom build process:
 ### All CSS and custom fonts
 
 <CodeBlock language='html'>
-{`<link rel="stylesheet" href="${publishedUrl('dist/css/sfds.css')}">
-<link rel="stylesheet" href="${publishedUrl('dist/css/fonts.css')}">`}
+{`<link rel="stylesheet" href="${publishedUrl('css/sfds.css')}">
+<link rel="stylesheet" href="${publishedUrl('css/fonts.css')}">`}
 </CodeBlock>
 
 ### Only utilities
 
 <CodeBlock language='html'>
-{`<link rel="stylesheet" href="${publishedUrl('dist/css/utilities.css')}">`}
+{`<link rel="stylesheet" href="${publishedUrl('css/utilities.css')}">`}
 </CodeBlock>
 
 :::tip

--- a/website/docs/develop/develop.mdx
+++ b/website/docs/develop/develop.mdx
@@ -39,9 +39,10 @@ is working by running:
 npm run build
 ```
 
-This should create files in the `dist/css`, `dist/react`, and
-`public` directories. Once you've confirmed that it's working,
-you can run one or both of the following:
+This should create `.css` files in the `css` directory, `index.js` and
+`index.mjs` in the `react` and `elements` directories, and a static website in
+the `public` directory. Once you've confirmed that it's working, you can run one
+or both of the following:
 
 - `npm run watch` watches the source files and rebuilds the CSS and JavaScript
   bundles when they change

--- a/website/docs/develop/install.mdx
+++ b/website/docs/develop/install.mdx
@@ -39,7 +39,7 @@ to import all of the design system CSS from the latest version of the npm
 package from [unpkg], you could add the following to your `<head>`:
 
 <CodeBlock language='html'>
-  {`<link rel="stylesheet" href="${publishedUrl('/dist/css/sfds.css')}">`}
+  {`<link rel="stylesheet" href="${publishedUrl('css/sfds.css')}">`}
 </CodeBlock>
 
 See the [CSS guide](/develop/css) for more detailed usage instructions.

--- a/website/docs/develop/javascript.mdx
+++ b/website/docs/develop/javascript.mdx
@@ -7,7 +7,7 @@ bundles:
     desc: The <sfgov-icon> custom element implementation
 ---
 
-import manifest from '@sfgov/design-system/dist/css/utilities.json'
+import manifest from '@sfgov/design-system/css/utilities.json'
 /* import { BundleTable } from '@site/src/components' */
 /* export const bundles = BundleTable.decorate(manifest.files, frontMatter.bundles) */
 

--- a/website/docs/libraries/tailwindClasses.mdx
+++ b/website/docs/libraries/tailwindClasses.mdx
@@ -7,7 +7,7 @@ hide_table_of_contents: true
 ---
 
 import TailwindView from "@site/src/components/TailwindDoc/tailwindView.js"
-import tailwindClasses from "@sfgov/design-system/dist/css/utilities.json"
+import tailwindClasses from "@sfgov/design-system/css/utilities.json"
 
 Below is a complete list of the customized Tailwind utility classes we use as a central part of the SF design system.
 

--- a/website/src/components/EncapsulatedStyleRoot.tsx
+++ b/website/src/components/EncapsulatedStyleRoot.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import root from 'react-shadow'
 import useIsBrowser from '@docusaurus/useIsBrowser'
 // eslint-disable-next-line import/no-webpack-loader-syntax
-import sfdsStyles from '!!raw-loader!@sfgov/design-system/dist/css/sfds.css'
+import sfdsStyles from '!!raw-loader!@sfgov/design-system/css/sfds.css'
 import { getCssText, GlobalStaticStyles } from '@sfgov/design-system/react'
 
 export default function EncapsulatedStyleRoot ({ children, ...props }) {

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -6,7 +6,7 @@
  * work well for content-centric websites.
  */
 
-@import '../../../dist/css/utilities.css';
+@import '../../../css/utilities.css';
 @import 'masonry-styles.css';
 
 @tailwind base;

--- a/website/src/plugins/sfgov/index.js
+++ b/website/src/plugins/sfgov/index.js
@@ -1,5 +1,5 @@
 const { join } = require('path')
-const { getPreloadLinks } = require('../../../../dist/react')
+const { getPreloadLinks } = require('../../../../react')
 const aliases = {
   '@sfgov/design-system': join(__dirname, '../../../..') + '/'
 }

--- a/website/tsconfig.json
+++ b/website/tsconfig.json
@@ -2,6 +2,11 @@
   "extends": "@tsconfig/docusaurus/tsconfig.json",
   "compilerOptions": {
     "baseUrl": ".",
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "paths": {
+      "@sfgov/design-system/react": [
+        "../react"
+      ]
+    }
   }
 }


### PR DESCRIPTION
This fixes TypeScript type hinting and simplifies the directory structure of the published package by removing the top-level `dist` directory and placing the built JS + TS files—`index.js` (CommonJS), `index.mjs` (ESM), and `.d.ts` + `.d.mts` (TypeScript outputs) in the `elements` and `react` directories.

### Before
```
├── css
│   └── src/*.css
├── elements
│   └── src/*.js
├── react
│   └── src/*.js
├── dist              (built)
│   ├── css/*.css
│   ├── elements/*.js
│   └── react/*.js
└── package.json
```

### After
```
├── css
│   ├── src/*.css
│   └── *.css          (built)
├── elements
│   ├── src/*.js
│   └── index.*        (built)
├── react
│   ├── src/*.{ts,tsx}
│   └── index.*        (built)
└── package.json
```

There is one (IMO) medium-size tradeoff here: **We can't lint unresolved imports without building the JS** because `import { ... } from '../react'` won't resolve until `react/index.js` or `react/index.mjs` are bundled. The current workaround is a combination of setting the severity of the ESLint `import/no-unresolved` rule to `warn` and `// eslint-ignore-next-line` comments above offending lines.

Being able to configure Docusaurus with a `tsconfig.json` is nice because we can provide an import alias for `@sfgov/design-system/react`, but not all of our source files are TypeScript and hacking Storybook's webpack config is not something I have the stomach for right now. 🤢 