### PR TITLE
Box block, VariantProps fix

### DIFF
--- a/react/src/components/Box.tsx
+++ b/react/src/components/Box.tsx
@@ -1,6 +1,8 @@
 import { styled } from '../stitches.config'
 import type { VariantProps } from '../utils'
 
-export const Box = styled('div')
+export const Box = styled('div', {
+  display: 'block'
+})
 
 export type BoxProps = VariantProps<typeof Box>

--- a/react/src/components/Flex.tsx
+++ b/react/src/components/Flex.tsx
@@ -13,4 +13,7 @@ export const Flex = styled(Box, {
   }
 })
 
-export type FlexVariant = VariantProps<typeof Flex>
+export type FlexProps = VariantProps<typeof Flex>
+
+// FIXME[1.0]: remove this alias
+export type FlexVariant = FlexProps

--- a/react/src/utils.tsx
+++ b/react/src/utils.tsx
@@ -1,8 +1,8 @@
 import React, { ComponentProps, ComponentType } from 'react'
 
-export type { VariantProps } from '@stitches/react'
+// XXX: export type { VariantProps } from '@stitches/react'
 
-// export type VariantProps<T> = JSX.IntrinsicAttributes & (T extends ComponentType ? ComponentProps<T> : T)
+export type VariantProps<T> = JSX.IntrinsicAttributes & (T extends ComponentType ? ComponentProps<T> : T)
 
 export function identity (v: any) {
   return v

--- a/react/src/utils.tsx
+++ b/react/src/utils.tsx
@@ -1,4 +1,8 @@
-import React, { Component, ComponentProps, ComponentType } from 'react'
+import React, { ComponentProps, ComponentType } from 'react'
+
+export type { VariantProps } from '@stitches/react'
+
+// export type VariantProps<T> = JSX.IntrinsicAttributes & (T extends ComponentType ? ComponentProps<T> : T)
 
 export function identity (v: any) {
   return v
@@ -21,5 +25,3 @@ export function withFixedProps (
     return <Component {...fixed} {...props} />
   }
 }
-
-export type VariantProps<T, P extends {} = T extends ComponentType ? ComponentProps<T> : T> = T & JSX.IntrinsicAttributes


### PR DESCRIPTION
Two things:

1. I set `display: block` in the default styles for `<Box>`, which simplifies `<Box as='a'>` or any other element that isn't block-level by default.
2. I replaced our broken `VariantProps` type with the one from Stitches. Let's see if this improves autocompletion and errors with the `as` prop in sfgov-next. 🤞 