### PR TITLE
Update the React components to use Rubik as the default font

### DIFF
--- a/react/src/constants.ts
+++ b/react/src/constants.ts
@@ -44,5 +44,14 @@ export const defaultFonts: FontSpec[] = [
     weights: {
       normal: 400
     }
+  },
+  {
+    name: 'Rubik',
+    fallbacks: ['ui-sans-serif', 'san-serif'],
+    weights: {
+      light: 300,
+      normal: 400,
+      bold: 600
+    }
   }
 ]

--- a/react/src/theme/typography.ts
+++ b/react/src/theme/typography.ts
@@ -3,8 +3,8 @@ import { defaultFonts } from '../constants'
 
 export const fonts = {
   body: '$sans',
-  sans: '$RobotoFlex',
-  slab: '$RobotoSlab',
+  sans: '$Rubik',
+  slab: '$Rubik',
   monospace: '$RobotoMono',
   chinese: '$NotoSansTC',
   ...Object.fromEntries(


### PR DESCRIPTION
This PR updates the fonts used by the React library to use Rubik as the default font face as specified [here](https://design-system.sf.gov/design/typography/)